### PR TITLE
fix: initialize NotifyResourceUsageChangesUseCase with current state to prevent false notifications to prevent false notifications

### DIFF
--- a/src/application/usecases/notify_resource_usage_changes.rs
+++ b/src/application/usecases/notify_resource_usage_changes.rs
@@ -19,12 +19,17 @@ where
     R: ResourceUsageRepository,
     N: Notifier,
 {
-    pub fn new(repository: R, notifier: N) -> Self {
-        Self {
+    pub async fn new(repository: R, notifier: N) -> Result<Self, ApplicationError> {
+        let instance = Self {
             repository,
             notifier,
             previous_state: tokio::sync::Mutex::new(HashMap::new()),
-        }
+        };
+
+        let current_usages = instance.fetch_current_usages().await?;
+        *instance.previous_state.lock().await = current_usages;
+
+        Ok(instance)
     }
 
     pub async fn poll_once(&self) -> Result<(), ApplicationError> {

--- a/src/bin/watcher.rs
+++ b/src/bin/watcher.rs
@@ -107,8 +107,19 @@ where
     R: ResourceUsageRepository,
     N: Notifier,
 {
-    let usecase = NotifyResourceUsageChangesUseCase::new(repository, notifier);
     let interval = Duration::from_secs(interval_secs);
+
+    println!("🔍 初期状態を読み込んでいます...");
+    let usecase = match NotifyResourceUsageChangesUseCase::new(repository, notifier).await {
+        Ok(uc) => {
+            println!("✅ 初期状態の読み込みが完了しました");
+            uc
+        }
+        Err(e) => {
+            eprintln!("❌ 初期化エラー: {}", e);
+            std::process::exit(1);
+        }
+    };
 
     println!("🔍 カレンダー監視を開始します（間隔: {:?}）", interval);
 


### PR DESCRIPTION
# Why

プロセス開始時に登録されてあるすべてのResourceUsageが新規作成としてNotifyされる問題があった

# What

NotifyUsecaseを初期化するタイミングでstateを更新し一回目のNotifyで差分が検知されないようにした。