### PR TITLE
feat: Add "all" device specification across all layers

### DIFF
--- a/src/domain/aggregates/resource_usage/factory/mod.rs
+++ b/src/domain/aggregates/resource_usage/factory/mod.rs
@@ -10,4 +10,4 @@
 /// リソースファクトリの実装
 pub mod resource_factory;
 
-pub use resource_factory::{ResourceFactory, ResourceFactoryError};
+pub use resource_factory::{ResourceFactory, ResourceFactoryError, SPEC_ALL};

--- a/src/domain/aggregates/resource_usage/factory/resource_factory.rs
+++ b/src/domain/aggregates/resource_usage/factory/resource_factory.rs
@@ -249,6 +249,14 @@ mod tests {
             .unwrap();
 
         assert_eq!(resources.len(), 3);
+        assert_eq!(
+            resources,
+            vec![
+                Resource::Gpu(Gpu::new("Thalys".to_string(), 0, "A100".to_string())),
+                Resource::Gpu(Gpu::new("Thalys".to_string(), 1, "A100".to_string())),
+                Resource::Gpu(Gpu::new("Thalys".to_string(), 2, "RTX6000".to_string())),
+            ]
+        );
     }
 
     #[test]

--- a/src/domain/aggregates/resource_usage/factory/resource_factory.rs
+++ b/src/domain/aggregates/resource_usage/factory/resource_factory.rs
@@ -3,7 +3,10 @@ use crate::domain::aggregates::resource_usage::value_objects::{Gpu, Resource};
 /// 全デバイス指定を表すデバイス指定記法
 pub const SPEC_ALL: &str = "all";
 
-/// デバイス指定記法からResourceオブジェクトを生成するファクトリ
+/// デバイス指定記法と Resource オブジェクトを相互変換するファクトリ
+///
+/// サーバーのデバイスカタログ `&[(u32, String)]` を共通の入力として、
+/// パース（spec → Resources）とフォーマット（Resources → spec）の対称な操作を提供する。
 pub struct ResourceFactory;
 
 impl ResourceFactory {
@@ -19,56 +22,84 @@ impl ResourceFactory {
     /// # Arguments
     /// * `spec` - デバイス指定文字列
     /// * `server_name` - サーバー名
-    /// * `all_device_ids` - サーバーの全デバイスIDリスト（"all"指定時に使用）
-    /// * `device_lookup` - デバイスIDからモデル名を取得するクロージャ
-    ///
-    /// # Returns
-    /// Resourceのリスト
-    ///
-    /// # Errors
-    /// - デバイス指定の形式が不正な場合
-    /// - 指定されたデバイスが存在しない場合
+    /// * `server_devices` - サーバーのデバイスカタログ（ID, モデル名）
     pub fn create_gpus_from_spec(
         spec: &str,
         server_name: &str,
-        all_device_ids: &[u32],
-        device_lookup: impl Fn(u32) -> Option<String>,
+        server_devices: &[(u32, String)],
     ) -> Result<Vec<Resource>, ResourceFactoryError> {
         let device_numbers = if spec == SPEC_ALL {
-            all_device_ids.to_vec()
+            server_devices.iter().map(|(id, _)| *id).collect()
         } else {
             Self::parse_device_numbers(spec)?
         };
 
         let mut resources = Vec::new();
         for device_num in device_numbers {
-            let model =
-                device_lookup(device_num).ok_or_else(|| ResourceFactoryError::DeviceNotFound {
+            let model = server_devices
+                .iter()
+                .find(|(id, _)| *id == device_num)
+                .map(|(_, model)| model.clone())
+                .ok_or_else(|| ResourceFactoryError::DeviceNotFound {
                     server: server_name.to_string(),
                     device_id: device_num,
                 })?;
 
-            let gpu = Gpu::new(server_name.to_string(), device_num, model);
-            resources.push(Resource::Gpu(gpu));
+            resources.push(Resource::Gpu(Gpu::new(
+                server_name.to_string(),
+                device_num,
+                model,
+            )));
         }
 
         Ok(resources)
     }
 
-    /// デバイス番号のパース（内部ヘルパー）
+    /// Resource のリストからデバイス指定記法を生成
     ///
-    /// "0-2,5,7-9" のような記法をパースして、個別のデバイス番号のリストに展開します。
+    /// サーバーの全デバイスが含まれている場合は "all" を返す。
+    /// それ以外はデバイス番号のカンマ区切り（例: "0,1,5,7"）を返す。
     ///
     /// # Arguments
-    /// * `spec` - デバイス指定文字列
+    /// * `resources` - GPUリソースのリスト
+    /// * `server_devices` - サーバーのデバイスカタログ（ID, モデル名）
+    pub fn format_gpu_spec(
+        resources: &[Resource],
+        server_devices: &[(u32, String)],
+    ) -> Option<String> {
+        let mut device_numbers: Vec<u32> = resources
+            .iter()
+            .filter_map(|r| match r {
+                Resource::Gpu(gpu) => Some(gpu.device_number()),
+                _ => None,
+            })
+            .collect();
+
+        if device_numbers.is_empty() {
+            return None;
+        }
+
+        if device_numbers.len() == server_devices.len()
+            && server_devices
+                .iter()
+                .all(|(id, _)| device_numbers.contains(id))
+        {
+            return Some(SPEC_ALL.to_string());
+        }
+
+        device_numbers.sort_unstable();
+        Some(
+            device_numbers
+                .iter()
+                .map(|n| n.to_string())
+                .collect::<Vec<_>>()
+                .join(","),
+        )
+    }
+
+    /// デバイス番号のパース（内部ヘルパー）
     ///
-    /// # Returns
-    /// デバイス番号のリスト
-    ///
-    /// # Errors
-    /// - 形式が不正な場合
-    /// - 数値として解釈できない場合
-    /// - 範囲指定が不正な場合
+    /// "0-2,5,7-9" のような記法をパースして、個別のデバイス番号のリストに展開する。
     fn parse_device_numbers(spec: &str) -> Result<Vec<u32>, ResourceFactoryError> {
         let mut numbers = Vec::new();
 
@@ -164,6 +195,14 @@ impl crate::domain::errors::DomainError for ResourceFactoryError {}
 mod tests {
     use super::*;
 
+    fn test_devices() -> Vec<(u32, String)> {
+        vec![
+            (0, "A100".to_string()),
+            (1, "A100".to_string()),
+            (2, "RTX6000".to_string()),
+        ]
+    }
+
     #[test]
     fn test_parse_single_device() {
         let result = ResourceFactory::parse_device_numbers("0").unwrap();
@@ -223,32 +262,18 @@ mod tests {
 
     #[test]
     fn test_create_gpus_from_spec() {
-        let resources =
-            ResourceFactory::create_gpus_from_spec("0-1", "Thalys", &[0, 1], |device_id| {
-                match device_id {
-                    0 => Some("A100".to_string()),
-                    1 => Some("A100".to_string()),
-                    _ => None,
-                }
-            })
-            .unwrap();
+        let devices = test_devices();
+        let resources = ResourceFactory::create_gpus_from_spec("0-1", "Thalys", &devices).unwrap();
 
         assert_eq!(resources.len(), 2);
     }
 
     #[test]
     fn test_create_gpus_from_spec_all() {
+        let devices = test_devices();
         let resources =
-            ResourceFactory::create_gpus_from_spec(SPEC_ALL, "Thalys", &[0, 1, 2], |device_id| {
-                match device_id {
-                    0 | 1 => Some("A100".to_string()),
-                    2 => Some("RTX6000".to_string()),
-                    _ => None,
-                }
-            })
-            .unwrap();
+            ResourceFactory::create_gpus_from_spec(SPEC_ALL, "Thalys", &devices).unwrap();
 
-        assert_eq!(resources.len(), 3);
         assert_eq!(
             resources,
             vec![
@@ -261,17 +286,41 @@ mod tests {
 
     #[test]
     fn test_create_gpus_device_not_found() {
-        let result =
-            ResourceFactory::create_gpus_from_spec("0-2", "Thalys", &[0, 1], |device_id| {
-                match device_id {
-                    0 | 1 => Some("A100".to_string()),
-                    _ => None,
-                }
-            });
+        let devices = vec![(0, "A100".to_string()), (1, "A100".to_string())];
+        let result = ResourceFactory::create_gpus_from_spec("0-2", "Thalys", &devices);
 
         assert!(matches!(
             result,
             Err(ResourceFactoryError::DeviceNotFound { .. })
         ));
+    }
+
+    #[test]
+    fn test_format_gpu_spec_all_devices() {
+        let devices = test_devices();
+        let resources =
+            ResourceFactory::create_gpus_from_spec(SPEC_ALL, "Thalys", &devices).unwrap();
+
+        assert_eq!(
+            ResourceFactory::format_gpu_spec(&resources, &devices),
+            Some("all".to_string())
+        );
+    }
+
+    #[test]
+    fn test_format_gpu_spec_partial_devices() {
+        let devices = test_devices();
+        let resources = ResourceFactory::create_gpus_from_spec("0,2", "Thalys", &devices).unwrap();
+
+        assert_eq!(
+            ResourceFactory::format_gpu_spec(&resources, &devices),
+            Some("0,2".to_string())
+        );
+    }
+
+    #[test]
+    fn test_format_gpu_spec_empty() {
+        let devices = test_devices();
+        assert_eq!(ResourceFactory::format_gpu_spec(&[], &devices), None);
     }
 }

--- a/src/infrastructure/repositories/resource_usage/google_calendar/repository.rs
+++ b/src/infrastructure/repositories/resource_usage/google_calendar/repository.rs
@@ -1,7 +1,7 @@
 use super::id_mapper::{ExternalId, IdMapper};
 use crate::domain::aggregates::resource_usage::{
     entity::ResourceUsage,
-    factory::ResourceFactory,
+    factory::{ResourceFactory, SPEC_ALL},
     value_objects::{Resource, TimePeriod, UsageId},
 };
 use crate::domain::common::EmailAddress;
@@ -296,7 +296,7 @@ impl GoogleCalendarUsageRepository {
                 .iter()
                 .all(|d| device_numbers.contains(&d.id))
         {
-            return Some(crate::domain::aggregates::resource_usage::factory::SPEC_ALL.to_string());
+            return Some(SPEC_ALL.to_string());
         }
 
         device_numbers.sort_unstable();

--- a/src/infrastructure/repositories/resource_usage/google_calendar/repository.rs
+++ b/src/infrastructure/repositories/resource_usage/google_calendar/repository.rs
@@ -254,7 +254,8 @@ impl GoogleCalendarUsageRepository {
             RepositoryError::Unknown(format!("サーバーが見つかりません: {}", resource_context))
         })?;
 
-        ResourceFactory::create_gpus_from_spec(title, &server.name, |device_id| {
+        let all_device_ids: Vec<u32> = server.devices.iter().map(|d| d.id).collect();
+        ResourceFactory::create_gpus_from_spec(title, &server.name, &all_device_ids, |device_id| {
             server
                 .devices
                 .iter()
@@ -267,7 +268,8 @@ impl GoogleCalendarUsageRepository {
     /// ResourcesからGPUデバイス仕様文字列を生成
     ///
     /// GPUリソースからデバイス番号を抽出してソートし、
-    /// カンマ区切りの文字列として返す（例: "0,1,5,7"）
+    /// カンマ区切りの文字列として返す（例: "0,1,5,7"）。
+    /// サーバーの全デバイスが含まれている場合は "all" を返す。
     fn format_gpu_spec(&self, resources: &[Resource]) -> Option<String> {
         let mut device_numbers: Vec<u32> = resources
             .iter()
@@ -279,6 +281,22 @@ impl GoogleCalendarUsageRepository {
 
         if device_numbers.is_empty() {
             return None;
+        }
+
+        // サーバーの全デバイスが含まれている場合は "all" を返す
+        let server_name = resources.iter().find_map(|r| match r {
+            Resource::Gpu(gpu) => Some(gpu.server()),
+            _ => None,
+        });
+        if let Some(server_name) = server_name
+            && let Some(server) = self.config.get_server(server_name)
+            && device_numbers.len() == server.devices.len()
+            && server
+                .devices
+                .iter()
+                .all(|d| device_numbers.contains(&d.id))
+        {
+            return Some(crate::domain::aggregates::resource_usage::factory::SPEC_ALL.to_string());
         }
 
         device_numbers.sort_unstable();

--- a/src/infrastructure/repositories/resource_usage/google_calendar/repository.rs
+++ b/src/infrastructure/repositories/resource_usage/google_calendar/repository.rs
@@ -1,7 +1,7 @@
 use super::id_mapper::{ExternalId, IdMapper};
 use crate::domain::aggregates::resource_usage::{
     entity::ResourceUsage,
-    factory::{ResourceFactory, SPEC_ALL},
+    factory::ResourceFactory,
     value_objects::{Resource, TimePeriod, UsageId},
 };
 use crate::domain::common::EmailAddress;
@@ -254,60 +254,16 @@ impl GoogleCalendarUsageRepository {
             RepositoryError::Unknown(format!("サーバーが見つかりません: {}", resource_context))
         })?;
 
-        let all_device_ids: Vec<u32> = server.devices.iter().map(|d| d.id).collect();
-        ResourceFactory::create_gpus_from_spec(title, &server.name, &all_device_ids, |device_id| {
-            server
-                .devices
-                .iter()
-                .find(|d| d.id == device_id)
-                .map(|d| d.model.clone())
-        })
-        .map_err(|e| RepositoryError::Unknown(e.to_string()))
+        let server_devices = Self::to_device_catalog(&server.devices);
+        ResourceFactory::create_gpus_from_spec(title, &server.name, &server_devices)
+            .map_err(|e| RepositoryError::Unknown(e.to_string()))
     }
 
-    /// ResourcesからGPUデバイス仕様文字列を生成
-    ///
-    /// GPUリソースからデバイス番号を抽出してソートし、
-    /// カンマ区切りの文字列として返す（例: "0,1,5,7"）。
-    /// サーバーの全デバイスが含まれている場合は "all" を返す。
-    fn format_gpu_spec(&self, resources: &[Resource]) -> Option<String> {
-        let mut device_numbers: Vec<u32> = resources
-            .iter()
-            .filter_map(|r| match r {
-                Resource::Gpu(gpu) => Some(gpu.device_number()),
-                _ => None,
-            })
-            .collect();
-
-        if device_numbers.is_empty() {
-            return None;
-        }
-
-        // サーバーの全デバイスが含まれている場合は "all" を返す
-        let server_name = resources.iter().find_map(|r| match r {
-            Resource::Gpu(gpu) => Some(gpu.server()),
-            _ => None,
-        });
-        if let Some(server_name) = server_name
-            && let Some(server) = self.config.get_server(server_name)
-            && device_numbers.len() == server.devices.len()
-            && server
-                .devices
-                .iter()
-                .all(|d| device_numbers.contains(&d.id))
-        {
-            return Some(SPEC_ALL.to_string());
-        }
-
-        device_numbers.sort_unstable();
-
-        Some(
-            device_numbers
-                .iter()
-                .map(|n| n.to_string())
-                .collect::<Vec<_>>()
-                .join(","),
-        )
+    /// DeviceConfig スライスをドメイン層のデバイスカタログ形式に変換
+    fn to_device_catalog(
+        devices: &[crate::infrastructure::config::resource_config::DeviceConfig],
+    ) -> Vec<(u32, String)> {
+        devices.iter().map(|d| (d.id, d.model.clone())).collect()
     }
 
     /// ResourceUsageから適切なカレンダーIDを取得
@@ -376,9 +332,15 @@ impl GoogleCalendarUsageRepository {
     fn create_event_from_usage(&self, usage: &ResourceUsage) -> Result<Event, RepositoryError> {
         // 注: get_calendar_id_for_usageで検証済みのため、resources()[0]は安全に使用できる
         let summary = match &usage.resources()[0] {
-            Resource::Gpu(_) => self.format_gpu_spec(usage.resources()).ok_or_else(|| {
-                RepositoryError::Unknown("GPUデバイス仕様の生成に失敗しました".to_string())
-            })?,
+            Resource::Gpu(gpu) => {
+                let server = self.config.get_server(gpu.server()).ok_or_else(|| {
+                    RepositoryError::Unknown(format!("サーバーが見つかりません: {}", gpu.server()))
+                })?;
+                let server_devices = Self::to_device_catalog(&server.devices);
+                ResourceFactory::format_gpu_spec(usage.resources(), &server_devices).ok_or_else(
+                    || RepositoryError::Unknown("GPUデバイス仕様の生成に失敗しました".to_string()),
+                )?
+            }
             Resource::Room { name } => name.clone(),
         };
 

--- a/src/interface/slack/block_actions/modal_state_change.rs
+++ b/src/interface/slack/block_actions/modal_state_change.rs
@@ -62,7 +62,7 @@ where
             );
             view_container.view_id.clone()
         }
-        SlackInteractionActionContainer::Message(_) => {
+        _ => {
             error!("❌ モーダル外のインタラクションです");
             return Ok(());
         }

--- a/src/interface/slack/constants.rs
+++ b/src/interface/slack/constants.rs
@@ -11,6 +11,8 @@ pub const ACTION_RESERVE_SERVER_SELECT: &str = "reserve_server_select";
 pub const ACTION_RESERVE_ROOM_SELECT: &str = "reserve_room_select";
 /// デバイス（GPU）選択のチェックボックスアクション
 pub const ACTION_RESERVE_DEVICES: &str = "reserve_devices";
+/// 全デバイス選択を表すチェックボックス値（ドメイン層の SPEC_ALL と同値）
+pub const VALUE_ALL_DEVICES: &str = "all";
 /// 予約開始日の日付ピッカーアクション
 pub const ACTION_RESERVE_START_DATE: &str = "reserve_start_date";
 /// 予約開始時刻のタイムピッカーアクション

--- a/src/interface/slack/constants.rs
+++ b/src/interface/slack/constants.rs
@@ -11,8 +11,6 @@ pub const ACTION_RESERVE_SERVER_SELECT: &str = "reserve_server_select";
 pub const ACTION_RESERVE_ROOM_SELECT: &str = "reserve_room_select";
 /// デバイス（GPU）選択のチェックボックスアクション
 pub const ACTION_RESERVE_DEVICES: &str = "reserve_devices";
-/// 全デバイス選択を表すチェックボックス値（ドメイン層の SPEC_ALL と同値）
-pub const VALUE_ALL_DEVICES: &str = "all";
 /// 予約開始日の日付ピッカーアクション
 pub const ACTION_RESERVE_START_DATE: &str = "reserve_start_date";
 /// 予約開始時刻のタイムピッカーアクション

--- a/src/interface/slack/view_submissions/reserve.rs
+++ b/src/interface/slack/view_submissions/reserve.rs
@@ -85,8 +85,7 @@ where
             extract_form_data::get_selected_options(view_submission, ACTION_RESERVE_DEVICES);
         info!("  → 選択デバイス数: {}", device_id_values.len());
 
-        if device_id_values.is_empty() {
-            // No specific devices selected - reserve entire server (all devices)
+        let all_devices = || {
             server_config
                 .devices
                 .iter()
@@ -98,6 +97,11 @@ where
                     ))
                 })
                 .collect()
+        };
+
+        if device_id_values.is_empty() || device_id_values.iter().any(|v| v == VALUE_ALL_DEVICES) {
+            // 未選択 or 「全てのデバイス」選択 → サーバーの全デバイスを予約
+            all_devices()
         } else {
             // Parse device IDs from values
             let mut gpu_resources = Vec::new();

--- a/src/interface/slack/view_submissions/reserve.rs
+++ b/src/interface/slack/view_submissions/reserve.rs
@@ -1,5 +1,6 @@
 //! リソース予約モーダル送信ハンドラ
 
+use crate::domain::aggregates::resource_usage::factory::SPEC_ALL;
 use crate::domain::aggregates::resource_usage::value_objects::resource::{Gpu, Resource};
 use crate::domain::ports::notifier::Notifier;
 use crate::domain::ports::repositories::ResourceUsageRepository;
@@ -99,7 +100,7 @@ where
                 .collect()
         };
 
-        if device_id_values.is_empty() || device_id_values.iter().any(|v| v == VALUE_ALL_DEVICES) {
+        if device_id_values.is_empty() || device_id_values.iter().any(|v| v == SPEC_ALL) {
             // 未選択 or 「全てのデバイス」選択 → サーバーの全デバイスを予約
             all_devices()
         } else {

--- a/src/interface/slack/views/modals/reserve.rs
+++ b/src/interface/slack/views/modals/reserve.rs
@@ -112,23 +112,24 @@ pub fn create_reserve_modal(
     SlackView::Modal(modal_view)
 }
 
-/// サーバーのデバイスリストから選択肢を生成
+/// サーバーのデバイスリストから選択肢を生成（先頭に「全てのデバイス」オプション付き）
 fn create_device_options(
     server: &crate::infrastructure::config::resource_config::ServerConfig,
 ) -> Vec<SlackBlockChoiceItem<SlackBlockText>> {
-    server
-        .devices
-        .iter()
-        .map(|device| {
-            SlackBlockChoiceItem::new(
-                SlackBlockText::Plain(SlackBlockPlainText::from(format!(
-                    "Device {} ({})",
-                    device.id, device.model
-                ))),
-                device.id.to_string(),
-            )
-        })
-        .collect()
+    let mut options = vec![SlackBlockChoiceItem::new(
+        SlackBlockText::Plain(SlackBlockPlainText::from("全てのデバイス".to_string())),
+        VALUE_ALL_DEVICES.to_string(),
+    )];
+    options.extend(server.devices.iter().map(|device| {
+        SlackBlockChoiceItem::new(
+            SlackBlockText::Plain(SlackBlockPlainText::from(format!(
+                "Device {} ({})",
+                device.id, device.model
+            ))),
+            device.id.to_string(),
+        )
+    }));
+    options
 }
 
 /// GPUサーバー選択ブロックを追加

--- a/src/interface/slack/views/modals/reserve.rs
+++ b/src/interface/slack/views/modals/reserve.rs
@@ -1,5 +1,6 @@
 //! リソース予約モーダルビルダー
 
+use crate::domain::aggregates::resource_usage::factory::SPEC_ALL;
 use crate::infrastructure::config::ResourceConfig;
 use crate::interface::slack::constants::*;
 use chrono::{Local, Timelike};
@@ -118,7 +119,7 @@ fn create_device_options(
 ) -> Vec<SlackBlockChoiceItem<SlackBlockText>> {
     let mut options = vec![SlackBlockChoiceItem::new(
         SlackBlockText::Plain(SlackBlockPlainText::from("全てのデバイス".to_string())),
-        VALUE_ALL_DEVICES.to_string(),
+        SPEC_ALL.to_string(),
     )];
     options.extend(server.devices.iter().map(|device| {
         SlackBlockChoiceItem::new(


### PR DESCRIPTION
## Summary
- Add `"all"` as a first-class device spec notation across domain, calendar, and Slack UI layers
- **Domain**: `ResourceFactory` now parses `"all"` spec to resolve all devices on a server
- **Calendar**: Events use `"all"` as title when all devices are reserved; parsing resolves it back to individual devices
- **Slack UI**: "全てのデバイス" checkbox option added at the top of the device list

## Deployment notes
- Calendar event titles change from `"0,1"` to `"all"` when all devices are reserved
- New code reads both formats (backward compatible)
- Rollback to pre-merge code cannot parse `"all"` titles — affected events would need manual title edits (e.g. `"all"` → `"0,1"`)

## Test plan
- [ ] Open the reservation modal and verify "全てのデバイス" appears as the first checkbox option
- [ ] Select "全てのデバイス" and submit — verify all devices on the server are reserved
- [ ] Select individual devices and submit — verify only those devices are reserved
- [ ] Leave devices unselected and submit — verify all devices are reserved (backward compatible)
- [ ] Verify calendar event title is `"all"` when all devices are reserved
- [ ] Verify calendar event with `"all"` title is correctly parsed back to all devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)