### PR TITLE
ci: exclude CHANGELOG.md from markdownlint

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -159,4 +159,6 @@ jobs:
       - name: markdownlint-cli2-action
         uses: DavidAnson/markdownlint-cli2-action@v20
         with:
-          globs: "**/*.md"
+          globs: |
+            **/*.md
+            !CHANGELOG.md


### PR DESCRIPTION
## Summary
- CHANGELOG.md is generated by release-please and its lines exceed this repo's 120-character markdownlint limit, so every release-please PR's Code Quality check fails on lint alone.
- Exclude CHANGELOG.md from the markdownlint globs.

## Test plan
- [x] Confirmed CHANGELOG.md only exists on the release-please branch, not main
- [ ] Verify release PR #85's Code Quality check goes green after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MH2Bck57sKrobqfPSQxtyV