### PR TITLE
fix: repair GPU observation DM delivery and spam issues

### DIFF
--- a/src/application/usecases/reconcile_observed_usages.rs
+++ b/src/application/usecases/reconcile_observed_usages.rs
@@ -41,6 +41,7 @@ where
     unreserved_threshold: Duration,
     duration_candidates: Vec<Duration>,
     proposed_keys: tokio::sync::Mutex<HashSet<(Resource, DateTime<Utc>)>>,
+    notified_unauthorized_keys: tokio::sync::Mutex<HashSet<(Resource, DateTime<Utc>)>>,
 }
 
 impl<R, O, I, P, U> ReconcileObservedUsagesUseCase<R, O, I, P, U>
@@ -74,6 +75,7 @@ where
             unreserved_threshold,
             duration_candidates,
             proposed_keys: tokio::sync::Mutex::new(HashSet::new()),
+            notified_unauthorized_keys: tokio::sync::Mutex::new(HashSet::new()),
         }
     }
 
@@ -138,9 +140,17 @@ where
             return Ok(());
         }
 
+        // 同一の観測セッションに対する再通知を防ぐ（提案と同じくUX上のスパム防止であり、
+        // 送信成功後にのみ記録することで失敗時の再試行を保つ）
+        let key = (observed.resource().clone(), observed.active_since());
+        if self.notified_unauthorized_keys.lock().await.contains(&key) {
+            return Ok(());
+        }
+
         self.unauthorized_notifier
             .notify(reservation, &actual_email)
             .await?;
+        self.notified_unauthorized_keys.lock().await.insert(key);
         Ok(())
     }
 
@@ -559,6 +569,43 @@ mod tests {
 
         // 未予約提案は発生しない（既に予約が存在するため）
         assert!(proposal_notifier.sent_proposals().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_unauthorized_notification_deduplicated_per_observation_session() {
+        let (usecase, repo, observer, identity_repo, _proposal_notifier, notifier) =
+            make_usecase(15);
+        identity_repo.add_link("other@example.com", os_system(), "kkawaguchi");
+
+        let now = Utc::now();
+        let reservation = make_reservation(
+            "owner@example.com",
+            now - Duration::hours(1),
+            now + Duration::hours(1),
+        );
+        repo.save(&reservation).await.unwrap();
+
+        let active_since = now - Duration::minutes(30);
+        observer.set_active_usages(vec![ObservedUsage::new(
+            gpu_resource(),
+            ExternalIdentity::new(os_system(), "kkawaguchi".to_string()),
+            active_since,
+        )]);
+
+        // 同一の観測セッションが続く限り、何度ポーリングしても通知は1回だけ
+        usecase.poll_once().await.unwrap();
+        usecase.poll_once().await.unwrap();
+        usecase.poll_once().await.unwrap();
+        assert_eq!(notifier.notified().len(), 1);
+
+        // プロセスが入れ替わる（観測開始時刻が変わる）と新しいセッションとして再通知する
+        observer.set_active_usages(vec![ObservedUsage::new(
+            gpu_resource(),
+            ExternalIdentity::new(os_system(), "kkawaguchi".to_string()),
+            active_since + Duration::minutes(10),
+        )]);
+        usecase.poll_once().await.unwrap();
+        assert_eq!(notifier.notified().len(), 2);
     }
 
     #[tokio::test]

--- a/src/bin/lab-resource-manager.rs
+++ b/src/bin/lab-resource-manager.rs
@@ -32,6 +32,14 @@ use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // tracingの初期化（RUST_LOGで制御、未設定時はinfo）
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
     // rustls暗号化プロバイダの初期化
     rustls::crypto::ring::default_provider()
         .install_default()

--- a/src/infrastructure/reservation_proposal/slack.rs
+++ b/src/infrastructure/reservation_proposal/slack.rs
@@ -153,13 +153,18 @@ fn build_proposal_blocks(
             };
             let value = serde_json::to_string(&payload).unwrap_or_default();
 
+            // action_idはブロック内で一意である必要がある（重複するとSlackがinvalid_blocksで拒否する）
             serde_json::json!({
                 "type": "button",
                 "text": {
                     "type": "plain_text",
                     "text": format_duration_label(*duration)
                 },
-                "action_id": ACTION_ACCEPT_RESERVATION_PROPOSAL,
+                "action_id": format!(
+                    "{}_{}",
+                    ACTION_ACCEPT_RESERVATION_PROPOSAL,
+                    duration.num_minutes()
+                ),
                 "value": value
             })
         })
@@ -251,6 +256,33 @@ mod tests {
         let json = serde_json::to_value(&blocks).unwrap();
         let elements = json[1]["elements"].as_array().unwrap();
         assert_eq!(elements.len(), candidates.len());
+    }
+
+    #[test]
+    fn test_build_proposal_blocks_action_ids_are_unique_within_block() {
+        let candidates = vec![Duration::hours(1), Duration::hours(2), Duration::hours(3)];
+        let proposal = sample_proposal(candidates.clone());
+        let Resource::Gpu(gpu) = proposal.resource() else {
+            unreachable!()
+        };
+
+        let blocks = build_proposal_blocks(&proposal, gpu, "test message");
+        let json = serde_json::to_value(&blocks).unwrap();
+        let action_ids: Vec<String> = json[1]["elements"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|e| e["action_id"].as_str().unwrap().to_string())
+            .collect();
+
+        // Slackはブロック内でaction_idが重複するとinvalid_blocksでメッセージ全体を拒否する
+        let unique: std::collections::HashSet<&String> = action_ids.iter().collect();
+        assert_eq!(unique.len(), candidates.len());
+
+        // gateway側は前方一致でディスパッチするため、全IDが規定のプレフィックスを持つこと
+        for id in &action_ids {
+            assert!(id.starts_with(ACTION_ACCEPT_RESERVATION_PROPOSAL));
+        }
     }
 
     #[test]

--- a/src/interface/slack/gateway.rs
+++ b/src/interface/slack/gateway.rs
@@ -156,7 +156,8 @@ where
                     )
                     .await?
                 }
-                ACTION_ACCEPT_RESERVATION_PROPOSAL => {
+                // 提案ボタンはブロック内一意性のため時間候補ごとの接尾辞付きIDなので前方一致で判定
+                id if id.starts_with(ACTION_ACCEPT_RESERVATION_PROPOSAL) => {
                     crate::interface::slack::block_actions::accept_proposal_button::handle(
                         self,
                         block_actions,


### PR DESCRIPTION
## Why

v1.3.0のGPU実利用観測を実サーバーで初めて有効化したところ、3つの問題が実運用テストで見つかった。

1. **事後予約提案DMが一度も送信されていない**: 時間候補ボタンが全て同一の`action_id`を持ち、Slackが`invalid_blocks`（`action_id already exists`）でメッセージ全体を拒否していた（chat.postMessage APIへの直接送信で実証済み）。
2. **無断使用DMが毎ポーリング再送される**: dedupがなく、30秒ポーリング×対象デバイス数のDMが利用者に殺到した。
3. **上記2件のエラーがログに一切出ない**: tracing subscriberが未初期化で、`tracing::error`が全て破棄されていた。1と2の調査を大きく難航させた。

## What

- 提案ボタンの`action_id`に時間候補（分）の接尾辞を付与してブロック内で一意にし、gatewayのディスパッチを前方一致に変更（所要時間の実データは従来通り`value`のペイロードから取得）
- 無断使用DMに提案DMと同じ観測セッション単位（リソース+利用開始時刻）のプロセス内dedupを適用。送信成功後にのみ記録し、失敗時の再試行は保つ
- `main`冒頭でtracing subscriberを初期化（`RUST_LOG`制御、既定`info`）

## How

- 新規テスト: ブロック内action_id一意性、無断使用DMのセッション単位dedup（再送抑止と新セッションでの再通知）
- 全81テスト成功、fmt/clippyクリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CnQDvNrbfqhtdy34mqRZYp