### PR TITLE
fix: clarify unauthorized-usage DM wording

### DIFF
--- a/src/infrastructure/unauthorized_usage_notifier/slack.rs
+++ b/src/infrastructure/unauthorized_usage_notifier/slack.rs
@@ -112,10 +112,10 @@ fn build_unauthorized_message(reserved_usage: &ResourceUsage) -> String {
     );
 
     format!(
-        "⚠️ 予約なしでリソースを使用しています\n\n📅 予約期間\n{}\n\n💻 予約リソース\n{}\n\n予約者: {}\n\n予約せずに利用している場合は、事前に予約を行ってください。",
+        "🚫 他の人が予約中のリソースを使用しています\n\nあなたが使用中のリソースには、現在以下の予約が入っています。\n\n👤 予約者\n{}\n\n📅 予約期間\n{}\n\n💻 予約リソース\n{}\n\n心当たりがある場合は、処理を停止するか予約者と調整してください。",
+        reserved_usage.owner_email().as_str(),
         time,
-        resources,
-        reserved_usage.owner_email().as_str()
+        resources
     )
 }
 
@@ -149,6 +149,6 @@ mod tests {
 
         assert!(message.contains("owner@example.com"));
         assert!(message.contains("Thalys"));
-        assert!(message.contains("予約なしでリソースを使用"));
+        assert!(message.contains("他の人が予約中のリソースを使用"));
     }
 }


### PR DESCRIPTION
## Why

無断使用検知DMの文言が「⚠️ 予約なしでリソースを使用しています」で始まっており、未予約利用（事後予約提案の対象）のケースと紛らわしい上、「他人の予約枠を使っている」という肝心の状況が受信者に伝わらなかった（v1.3.1の実運用テストで確認）。

## What

- 見出しを「🚫 他の人が予約中のリソースを使用しています」に変更し、予約者を先頭に表示
- 末尾の案内も「処理を停止するか予約者と調整」という実際に取るべき行動に変更

なお、v1.2.0ではチャンネル放送用の`templates.unauthorized`でカスタム可能だったが、#92のDM化でテンプレート機構ごと失われている。DM文言のテンプレート対応の復活は別issueとする。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CnQDvNrbfqhtdy34mqRZYp