### PR TITLE
docs: define reservations as the records the model can interpret

### DIFF
--- a/src/domain/ports/repositories/resource_usage.rs
+++ b/src/domain/ports/repositories/resource_usage.rs
@@ -9,6 +9,17 @@ use crate::domain::{
 use async_trait::async_trait;
 
 /// ResourceUsage集約のリポジトリポート
+///
+/// # 予約として扱う範囲
+/// 永続化層のレコードのうち、`ResourceUsage`として解釈できるものだけが予約である。
+/// 解釈できないレコードは予約ではなく、このモデルの外にある。検索結果に現れないのは
+/// 取りこぼしではなく、予約ではないものを返さないという意味である。
+///
+/// 永続化層が人の手による編集を受け付ける場合、予約の形式に沿わないレコードは
+/// 避けられない。それを予約として復元しようとはしない。
+///
+/// 予約されないまま使われるリソースは、実利用の観測（`ResourceUsageObserver`）が
+/// 扱う領域である。
 #[async_trait]
 pub trait ResourceUsageRepository {
     /// IDでResourceUsageを検索

--- a/src/domain/services/resource_usage/conflict_checker.rs
+++ b/src/domain/services/resource_usage/conflict_checker.rs
@@ -5,6 +5,14 @@ use crate::domain::services::resource_usage::errors::{ConflictCheckError, Resour
 /// リソース競合チェックサービス
 ///
 /// 指定された時間帯とリソースが既存の予約と競合しないかをチェックする
+///
+/// # 判定の範囲
+/// 判定の対象は予約である。永続化層にあって予約として解釈されないレコードは
+/// 予約ではないため、競合の対象にならない（`ResourceUsageRepository`を参照）。
+///
+/// したがって競合なしとは「予約と重ならない」ことであり、そのリソースが実際に
+/// 使われていないことは意味しない。予約されないまま使われるリソースは
+/// 実利用の観測側で扱う。
 #[derive(Debug, Clone, Default)]
 pub struct ResourceConflictChecker;
 


### PR DESCRIPTION
## Why

Follow-up to the conflict-check fix. Records a decision; no behavior changes.

Google Calendar is both the persistence layer and a calendar people edit by hand. Records that do not follow the reservation format are unavoidable — the Thalys calendar currently holds three entries titled "YANS" (meeting notes, not bookings), and Lyria/Freccia held entries naming devices that do not exist. Parse failures were being logged 285,689 times over four months without anyone noticing.

The open question was what the repository owes its callers when it meets such a record.

Treating them as *reservations that failed to load* makes every search result "possibly incomplete" and turns conflict detection into something with a known blind spot. That pushes a persistence-layer concern into the application's vocabulary — a leak.

The alternative, taken here: records the model cannot interpret are **not reservations**. They live outside the model. The repository returns every reservation, so nothing is missing and the contract holds.

This closes cleanly because unreserved usage is already someone else's job. `ResourceUsageObserver` and the post-hoc proposal flow exist precisely to catch resources being used without a booking. Someone who writes an unparseable title is in the same position as someone who books nothing at all, and that path is already covered.

## What

- `ResourceUsageRepository` — states which records count as reservations, that uninterpretable ones are outside the model (their absence from results is not a gap), that the repository will not try to recover them, and that unreserved usage belongs to the observation side.
- `ResourceConflictChecker` — "no conflict" means "does not overlap a reservation", not "the resource is free".

## Test plan

- [x] `cargo test` — 99 passed, unchanged
- [x] `cargo clippy --all-targets` — no warnings
- [x] `cargo fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KHaZgaoJcQjDGXZF9PJ9S
