### PR TITLE
feat: group post-hoc reservation proposals and make acceptance idempotent

### DIFF
--- a/src/application/usecases/accept_reservation_proposal.rs
+++ b/src/application/usecases/accept_reservation_proposal.rs
@@ -1,0 +1,359 @@
+use crate::application::error::ApplicationError;
+use crate::domain::aggregates::resource_usage::{
+    entity::ResourceUsage,
+    value_objects::{Resource, TimePeriod, UsageId},
+};
+use crate::domain::common::EmailAddress;
+use crate::domain::ports::repositories::ResourceUsageRepository;
+use crate::domain::services::ResourceConflictChecker;
+use chrono::{DateTime, Duration, Utc};
+use std::collections::HashSet;
+use std::sync::Arc;
+
+/// 実利用検知にもとづく事後予約の備考
+pub const POST_HOC_RESERVATION_NOTES: &str = "GPU実利用検知による事後予約";
+
+/// 事後予約の提案を受諾するユースケース
+///
+/// 提案の受諾は「予約を新しく作る」ではなく「この観測セッションの予約を、この長さにする」
+/// という意味を持つ。利用者は提案メッセージの時間候補ボタンを押し直せるため、
+/// 同じ観測セッションに対する受諾が複数回起きても予約は1件に保たれる必要がある。
+pub struct AcceptReservationProposalUseCase<R: ResourceUsageRepository> {
+    repository: Arc<R>,
+    conflict_checker: ResourceConflictChecker,
+}
+
+impl<R: ResourceUsageRepository> AcceptReservationProposalUseCase<R> {
+    /// 新しいユースケースインスタンスを作成
+    pub fn new(repository: Arc<R>) -> Self {
+        Self {
+            repository,
+            conflict_checker: ResourceConflictChecker::new(),
+        }
+    }
+
+    /// 提案を受諾して予約を確定する
+    ///
+    /// 同じ観測セッション（同一の予約者・利用開始時刻・リソース集合）に対する予約が
+    /// 既に存在する場合は、その期間を指定された長さに更新する。存在しない場合は新規作成する。
+    ///
+    /// # Arguments
+    /// * `owner_email` - 予約者
+    /// * `resources` - 実利用が観測されたリソース
+    /// * `active_since` - 利用開始時刻（予約の開始時刻になる）
+    /// * `duration` - 受諾された利用時間
+    ///
+    /// # Returns
+    /// 作成または更新された予約のID
+    ///
+    /// # Errors
+    /// - 他の予約と競合する場合
+    /// - リポジトリエラー
+    pub async fn execute(
+        &self,
+        owner_email: EmailAddress,
+        resources: Vec<Resource>,
+        active_since: DateTime<Utc>,
+        duration: Duration,
+    ) -> Result<UsageId, ApplicationError> {
+        let time_period = TimePeriod::new(active_since, active_since + duration)?;
+
+        let existing = self
+            .find_same_session_reservation(&owner_email, &resources, active_since, &time_period)
+            .await?;
+
+        // 既存予約の期間を更新する場合、自分自身は競合対象から外す
+        self.conflict_checker
+            .check_conflicts(
+                self.repository.as_ref(),
+                &time_period,
+                &resources,
+                existing.as_ref().map(|usage| usage.id()),
+            )
+            .await?;
+
+        let usage = match existing {
+            Some(existing) => ResourceUsage::reconstruct(
+                existing.id().clone(),
+                owner_email,
+                time_period,
+                resources,
+                existing.notes().cloned(),
+            )?,
+            None => ResourceUsage::new(
+                owner_email,
+                time_period,
+                resources,
+                Some(POST_HOC_RESERVATION_NOTES.to_string()),
+            )?,
+        };
+
+        self.repository.save(&usage).await?;
+
+        Ok(usage.id().clone())
+    }
+
+    /// 同じ観測セッションに対して既に作られた予約を探す
+    ///
+    /// 受諾しようとしている期間と重なる予約のうち、予約者・利用開始時刻・リソース集合が
+    /// 一致するものを同一セッションとみなす。終了時刻が過去になっていても対象に含める
+    /// 必要があるため、進行中・今後の予約に限定する検索は使わない。
+    async fn find_same_session_reservation(
+        &self,
+        owner_email: &EmailAddress,
+        resources: &[Resource],
+        active_since: DateTime<Utc>,
+        time_period: &TimePeriod,
+    ) -> Result<Option<ResourceUsage>, ApplicationError> {
+        let requested: HashSet<&Resource> = resources.iter().collect();
+
+        let candidates = self.repository.find_overlapping(time_period).await?;
+
+        Ok(candidates.into_iter().find(|usage| {
+            usage.owner_email() == owner_email
+                && usage.time_period().start() == active_since
+                && usage.resources().iter().collect::<HashSet<_>>() == requested
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::aggregates::resource_usage::value_objects::Gpu;
+    use crate::infrastructure::repositories::resource_usage::mock::MockUsageRepository;
+
+    fn gpu(device_number: u32) -> Resource {
+        Resource::Gpu(Gpu::new(
+            "Thalys".to_string(),
+            device_number,
+            "A100".to_string(),
+        ))
+    }
+
+    fn email(address: &str) -> EmailAddress {
+        EmailAddress::new(address.to_string()).unwrap()
+    }
+
+    /// 事後予約として保存済みの予約を作る
+    async fn save_post_hoc_reservation(
+        repository: &MockUsageRepository,
+        owner: &str,
+        resources: Vec<Resource>,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+    ) -> UsageId {
+        let usage = ResourceUsage::new(
+            email(owner),
+            TimePeriod::new(start, end).unwrap(),
+            resources,
+            Some(POST_HOC_RESERVATION_NOTES.to_string()),
+        )
+        .unwrap();
+        repository.save(&usage).await.unwrap();
+        usage.id().clone()
+    }
+
+    /// 保存されている全予約（終了済みを含む）
+    async fn all_reservations(repository: &MockUsageRepository) -> Vec<ResourceUsage> {
+        let far_past = Utc::now() - Duration::days(365);
+        let far_future = Utc::now() + Duration::days(365);
+        repository
+            .find_overlapping(&TimePeriod::new(far_past, far_future).unwrap())
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn accepting_twice_for_the_same_session_updates_the_period_instead_of_adding() {
+        let repository = Arc::new(MockUsageRepository::new());
+        let active_since = Utc::now() - Duration::hours(1);
+        let existing_id = save_post_hoc_reservation(
+            &repository,
+            "owner@example.com",
+            vec![gpu(0), gpu(1)],
+            active_since,
+            active_since + Duration::hours(2),
+        )
+        .await;
+
+        let usecase = AcceptReservationProposalUseCase::new(repository.clone());
+        let returned_id = usecase
+            .execute(
+                email("owner@example.com"),
+                vec![gpu(0), gpu(1)],
+                active_since,
+                Duration::hours(12),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(returned_id, existing_id, "既存予約が更新されるべき");
+
+        let reservations = all_reservations(&repository).await;
+        assert_eq!(reservations.len(), 1, "予約が増えてはいけない");
+        assert_eq!(
+            reservations[0].time_period().end(),
+            active_since + Duration::hours(12),
+            "受諾された長さに更新されるべき"
+        );
+    }
+
+    #[tokio::test]
+    async fn accepting_updates_even_when_the_existing_reservation_already_ended() {
+        let repository = Arc::new(MockUsageRepository::new());
+        // 2時間の受諾後に時間が経ち、既存予約の終了時刻が過去になっている状況
+        let active_since = Utc::now() - Duration::hours(5);
+        save_post_hoc_reservation(
+            &repository,
+            "owner@example.com",
+            vec![gpu(0)],
+            active_since,
+            active_since + Duration::hours(2),
+        )
+        .await;
+
+        let usecase = AcceptReservationProposalUseCase::new(repository.clone());
+        usecase
+            .execute(
+                email("owner@example.com"),
+                vec![gpu(0)],
+                active_since,
+                Duration::hours(12),
+            )
+            .await
+            .unwrap();
+
+        let reservations = all_reservations(&repository).await;
+        assert_eq!(
+            reservations.len(),
+            1,
+            "終了済みの予約も同一セッションとして扱い、更新するべき"
+        );
+    }
+
+    #[tokio::test]
+    async fn accepting_shorter_duration_shrinks_the_existing_reservation() {
+        let repository = Arc::new(MockUsageRepository::new());
+        let active_since = Utc::now() - Duration::hours(1);
+        save_post_hoc_reservation(
+            &repository,
+            "owner@example.com",
+            vec![gpu(0)],
+            active_since,
+            active_since + Duration::hours(12),
+        )
+        .await;
+
+        let usecase = AcceptReservationProposalUseCase::new(repository.clone());
+        usecase
+            .execute(
+                email("owner@example.com"),
+                vec![gpu(0)],
+                active_since,
+                Duration::hours(2),
+            )
+            .await
+            .unwrap();
+
+        let reservations = all_reservations(&repository).await;
+        assert_eq!(reservations.len(), 1);
+        assert_eq!(
+            reservations[0].time_period().end(),
+            active_since + Duration::hours(2),
+            "短い候補を押した場合は期間が縮むべき"
+        );
+    }
+
+    #[tokio::test]
+    async fn creates_a_new_reservation_when_no_session_matches() {
+        let repository = Arc::new(MockUsageRepository::new());
+        let active_since = Utc::now() - Duration::minutes(30);
+
+        let usecase = AcceptReservationProposalUseCase::new(repository.clone());
+        usecase
+            .execute(
+                email("owner@example.com"),
+                vec![gpu(0), gpu(1)],
+                active_since,
+                Duration::hours(3),
+            )
+            .await
+            .unwrap();
+
+        let reservations = all_reservations(&repository).await;
+        assert_eq!(reservations.len(), 1);
+        assert_eq!(
+            reservations[0].notes().map(String::as_str),
+            Some(POST_HOC_RESERVATION_NOTES),
+            "事後予約として備考が入るべき"
+        );
+        assert_eq!(
+            reservations[0].resources().len(),
+            2,
+            "観測された全リソースが1件の予約になるべき"
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_when_another_user_holds_an_overlapping_reservation() {
+        let repository = Arc::new(MockUsageRepository::new());
+        let active_since = Utc::now() - Duration::hours(1);
+        save_post_hoc_reservation(
+            &repository,
+            "someone-else@example.com",
+            vec![gpu(0)],
+            active_since,
+            active_since + Duration::hours(6),
+        )
+        .await;
+
+        let usecase = AcceptReservationProposalUseCase::new(repository.clone());
+        let result = usecase
+            .execute(
+                email("owner@example.com"),
+                vec![gpu(0)],
+                active_since,
+                Duration::hours(3),
+            )
+            .await;
+
+        assert!(
+            matches!(result, Err(ApplicationError::ResourceConflict { .. })),
+            "他人の予約と重なる場合は競合として拒否するべき, got {result:?}"
+        );
+        assert_eq!(
+            all_reservations(&repository).await.len(),
+            1,
+            "予約は増えない"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_different_resource_set_is_treated_as_a_separate_session() {
+        let repository = Arc::new(MockUsageRepository::new());
+        let active_since = Utc::now() - Duration::hours(1);
+        save_post_hoc_reservation(
+            &repository,
+            "owner@example.com",
+            vec![gpu(0)],
+            active_since,
+            active_since + Duration::hours(2),
+        )
+        .await;
+
+        // 同じ利用者・同じ開始時刻でも、別のGPUを使い始めた場合は別の予約になる
+        let usecase = AcceptReservationProposalUseCase::new(repository.clone());
+        usecase
+            .execute(
+                email("owner@example.com"),
+                vec![gpu(1)],
+                active_since,
+                Duration::hours(2),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(all_reservations(&repository).await.len(), 2);
+    }
+}

--- a/src/application/usecases/mod.rs
+++ b/src/application/usecases/mod.rs
@@ -42,6 +42,9 @@
 //! Application層は薄く保ち、ドメインロジックをDomain層に配置する。
 
 /// リソース使用予定を作成するユースケース
+/// 事後予約提案の受諾
+pub mod accept_reservation_proposal;
+
 pub mod create_resource_usage;
 /// リソース使用予定を削除するユースケース
 pub mod delete_resource_usage;
@@ -57,9 +60,12 @@ pub mod list_user_resource_usages;
 pub mod notify_future_resource_usage_changes;
 /// 実サーバーの利用状況と予約を突き合わせるユースケース
 pub mod reconcile_observed_usages;
+#[cfg(test)]
+mod reconcile_observed_usages_tests;
 /// リソース使用予定を更新するユースケース
 pub mod update_resource_usage;
 
+pub use accept_reservation_proposal::AcceptReservationProposalUseCase;
 pub use create_resource_usage::CreateResourceUsageUseCase;
 pub use delete_resource_usage::DeleteResourceUsageUseCase;
 pub use get_resource_usage_by_id::GetResourceUsageByIdUseCase;

--- a/src/application/usecases/reconcile_observed_usages.rs
+++ b/src/application/usecases/reconcile_observed_usages.rs
@@ -1,4 +1,5 @@
 use crate::application::error::ApplicationError;
+use crate::domain::aggregates::identity_link::value_objects::ExternalSystem;
 use crate::domain::aggregates::resource_usage::entity::ResourceUsage;
 use crate::domain::aggregates::resource_usage::value_objects::Resource;
 use crate::domain::common::EmailAddress;
@@ -8,9 +9,24 @@ use crate::domain::ports::{
     UnauthorizedUsageNotifier,
 };
 use chrono::{DateTime, Duration, Utc};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use tracing::error;
+use tracing::{error, info};
+
+/// 同じ機会に使い始めたとみなす観測開始時刻の幅
+///
+/// 複数のリソースを続けて使い始めると観測開始時刻が数秒〜数十秒ずれるため、
+/// この幅に収まるものはひとつの機会としてまとめて提案する。
+const SESSION_GROUPING_WINDOW: Duration = Duration::minutes(5);
+
+/// 利用者を識別するキー（外部システムの種類＋ユーザーID）
+///
+/// `ExternalIdentity`は紐付け日時を同一性に含むため、観測ごとに生成された値どうしでは
+/// 同じ利用者と判定できない。利用者の同一判定にはこのキーを使う。
+type UserKey = (ExternalSystem, String);
+
+/// 提案済みの機会を表すキー（利用者・正規化したリソース名・開始時刻）
+type ProposedSessionKey = (UserKey, Vec<String>, DateTime<Utc>);
 
 /// 実サーバーの利用状況と予約を突き合わせ、未予約利用の提案・無断使用の通知を行うユースケース
 ///
@@ -21,8 +37,12 @@ use tracing::error;
 /// - 予約が存在しない利用: `unreserved_threshold`以上継続していれば、
 ///   `ReservationProposalNotifier`経由で利用者本人に事後予約を提案する
 ///
+/// # 提案のまとめ
+/// 同じ利用者が近い時刻に使い始めたリソースは、ひとつの機会としてまとめて1件の提案にする。
+/// リソースごとに提案を分けると、利用者は使った枚数だけボタンを押すことになる。
+///
 /// # 重複提案の防止
-/// 同一の観測セッション（リソース＋観測開始時刻）に対しては一度だけ提案する。
+/// ひとつの機会（利用者＋リソース集合＋開始時刻）に対しては一度だけ提案する。
 /// この状態はビジネス不変条件ではなくUX上のスパム防止に過ぎないため、
 /// プロセス内メモリのみで保持し、永続化しない。
 pub struct ReconcileObservedUsagesUseCase<R, O, I, P, U>
@@ -40,7 +60,7 @@ where
     unauthorized_notifier: U,
     unreserved_threshold: Duration,
     duration_candidates: Vec<Duration>,
-    proposed_keys: tokio::sync::Mutex<HashSet<(Resource, DateTime<Utc>)>>,
+    proposed_keys: tokio::sync::Mutex<HashSet<ProposedSessionKey>>,
     notified_unauthorized_keys: tokio::sync::Mutex<HashSet<(Resource, DateTime<Utc>)>>,
 }
 
@@ -88,29 +108,75 @@ where
         let now = Utc::now();
         let current_usages = self.repository.find_future().await?;
 
+        let mut unreserved = Vec::new();
+
         for usage in &observed {
-            if let Err(e) = self.reconcile_one(usage, &current_usages, now).await {
-                error!(
-                    "実利用の突合処理に失敗しました (resource={}): {}",
-                    usage.resource(),
-                    e
-                );
+            match Self::find_active_reservation(&current_usages, usage.resource(), now) {
+                Some(reservation) => {
+                    if let Err(e) = self.reconcile_reserved(usage, reservation).await {
+                        error!(
+                            "実利用の突合処理に失敗しました (resource={}): {}",
+                            usage.resource(),
+                            e
+                        );
+                    }
+                }
+                // 未予約の利用は、同じ機会に使い始めた分をまとめて提案するため一旦集める
+                None if now - usage.active_since() >= self.unreserved_threshold => {
+                    unreserved.push(usage.clone());
+                }
+                None => {}
+            }
+        }
+
+        for session in Self::group_into_sessions(unreserved) {
+            if let Err(e) = self.propose_for_session(&session).await {
+                error!("事後予約の提案に失敗しました: {}", e);
             }
         }
 
         Ok(())
     }
 
-    async fn reconcile_one(
-        &self,
-        observed: &ObservedUsage,
-        current_usages: &[ResourceUsage],
-        now: DateTime<Utc>,
-    ) -> Result<(), ApplicationError> {
-        match Self::find_active_reservation(current_usages, observed.resource(), now) {
-            Some(reservation) => self.reconcile_reserved(observed, reservation).await,
-            None => self.reconcile_unreserved(observed, now).await,
+    /// 未予約の利用を「同じ機会に使い始めた一群」へ分ける
+    ///
+    /// 同一利用者が複数のリソースを続けて使い始めると、観測開始時刻は秒単位でずれる。
+    /// 利用者ごとに時刻順へ並べ、隣接する観測が`SESSION_GROUPING_WINDOW`以内であれば
+    /// 同じ機会とみなす。
+    fn group_into_sessions(unreserved: Vec<ObservedUsage>) -> Vec<Vec<ObservedUsage>> {
+        let mut by_user: HashMap<UserKey, Vec<ObservedUsage>> = HashMap::new();
+        for usage in unreserved {
+            by_user
+                .entry(Self::user_key(&usage))
+                .or_default()
+                .push(usage);
         }
+
+        let mut sessions = Vec::new();
+
+        for (_user, mut usages) in by_user {
+            usages.sort_by_key(|usage| usage.active_since());
+
+            let mut current: Vec<ObservedUsage> = Vec::new();
+            for usage in usages {
+                let starts_new_session = current.last().is_some_and(|last| {
+                    usage.active_since() - last.active_since() > SESSION_GROUPING_WINDOW
+                });
+
+                if starts_new_session {
+                    sessions.push(std::mem::take(&mut current));
+                }
+                current.push(usage);
+            }
+
+            if !current.is_empty() {
+                sessions.push(current);
+            }
+        }
+
+        // 提案の順序を観測開始時刻で安定させる（利用者ごとの走査順は不定のため）
+        sessions.sort_by_key(|session| session.first().map(|usage| usage.active_since()));
+        sessions
     }
 
     fn find_active_reservation<'a>(
@@ -154,49 +220,73 @@ where
         Ok(())
     }
 
-    /// 未予約利用が閾値を超えて継続していれば、利用者へ事後予約を提案する
-    async fn reconcile_unreserved(
-        &self,
-        observed: &ObservedUsage,
-        now: DateTime<Utc>,
-    ) -> Result<(), ApplicationError> {
-        if now - observed.active_since() < self.unreserved_threshold {
-            return Ok(());
-        }
-
-        // IdentityLink未登録の間は「提案済み」にせず、リンク後の次回ポーリングで再試行できるようにする
-        let Some(owner_email) = self.resolve_email(observed).await? else {
+    /// ひとつの機会にまとめた未予約利用について、利用者へ事後予約を提案する
+    async fn propose_for_session(&self, session: &[ObservedUsage]) -> Result<(), ApplicationError> {
+        // 時刻順に並んでいるため、先頭がこの機会の開始時刻を表す
+        let Some(first) = session.first() else {
             return Ok(());
         };
 
-        if self.already_proposed(observed).await {
+        // IdentityLink未登録の間は「提案済み」にせず、リンク後の次回ポーリングで再試行できるようにする
+        let Some(owner_email) = self.resolve_email(first).await? else {
+            return Ok(());
+        };
+
+        let resources: Vec<Resource> = session
+            .iter()
+            .map(|usage| usage.resource().clone())
+            .collect();
+        let key = Self::session_key(first, &resources);
+
+        if self.proposed_keys.lock().await.contains(&key) {
             return Ok(());
         }
 
+        info!(
+            "📨 事後予約を提案: owner={}, resources=[{}], active_since={}",
+            owner_email.as_str(),
+            resources
+                .iter()
+                .map(|resource| resource.to_string())
+                .collect::<Vec<_>>()
+                .join(", "),
+            first.active_since()
+        );
+
         let proposal = ReservationProposal::new(
-            observed.resource().clone(),
+            resources,
             owner_email,
-            observed.external_identity().clone(),
-            observed.active_since(),
+            first.external_identity().clone(),
+            first.active_since(),
             self.duration_candidates.clone(),
         );
         // 提案の送信（Slack DM等）が失敗しうるため、成功後にのみ「提案済み」として記録する。
         // 先に記録してしまうと、送信失敗時に永久に再試行されなくなる。
         self.proposal_notifier.propose(proposal).await?;
-        self.mark_proposed(observed).await;
+        self.proposed_keys.lock().await.insert(key);
         Ok(())
     }
 
-    /// 既に提案済みかどうかを確認
-    async fn already_proposed(&self, observed: &ObservedUsage) -> bool {
-        let key = (observed.resource().clone(), observed.active_since());
-        self.proposed_keys.lock().await.contains(&key)
+    /// 提案の重複判定に使うキー
+    ///
+    /// リソースの並びは観測順に依存するため、表示名で並べ替えて正規化する。
+    /// リソースが増えた場合は別の機会として扱い、改めて提案できるようにする。
+    fn session_key(first: &ObservedUsage, resources: &[Resource]) -> ProposedSessionKey {
+        let mut normalized: Vec<String> = resources
+            .iter()
+            .map(|resource| resource.to_string())
+            .collect();
+        normalized.sort();
+
+        (Self::user_key(first), normalized, first.active_since())
     }
 
-    /// 提案済みとして記録する
-    async fn mark_proposed(&self, observed: &ObservedUsage) {
-        let key = (observed.resource().clone(), observed.active_since());
-        self.proposed_keys.lock().await.insert(key);
+    /// 観測結果から利用者を識別するキーを作る
+    fn user_key(observed: &ObservedUsage) -> UserKey {
+        (
+            observed.external_identity().system().clone(),
+            observed.external_identity().user_id().to_string(),
+        )
     }
 
     /// 観測された外部識別情報からメールアドレスを解決する（IdentityLink未登録ならNone）
@@ -212,486 +302,5 @@ where
             )
             .await?;
         Ok(identity_link.map(|link| link.email().clone()))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::domain::aggregates::identity_link::{
-        entity::IdentityLink,
-        value_objects::{ExternalIdentity, ExternalSystem},
-    };
-    use crate::domain::aggregates::resource_usage::value_objects::{Gpu, TimePeriod};
-    use crate::domain::ports::NotificationError;
-    use crate::domain::ports::repositories::RepositoryError;
-    use crate::infrastructure::repositories::resource_usage::mock::MockUsageRepository;
-    use crate::infrastructure::reservation_proposal::MockReservationProposalNotifier;
-    use crate::infrastructure::resource_usage_observer::MockResourceUsageObserver;
-    use async_trait::async_trait;
-    use std::collections::HashMap;
-    use std::sync::Mutex as StdMutex;
-
-    #[derive(Default)]
-    struct InMemoryIdentityLinkRepository {
-        links: StdMutex<HashMap<String, IdentityLink>>,
-    }
-
-    impl InMemoryIdentityLinkRepository {
-        fn add_link(&self, email: &str, system: ExternalSystem, user_id: &str) {
-            let email_addr = EmailAddress::new(email.to_string()).unwrap();
-            let identity = ExternalIdentity::new(system, user_id.to_string());
-            let link = IdentityLink::with_external_identity(email_addr.clone(), identity);
-            self.links
-                .lock()
-                .unwrap()
-                .insert(email_addr.as_str().to_string(), link);
-        }
-    }
-
-    #[async_trait]
-    impl IdentityLinkRepository for InMemoryIdentityLinkRepository {
-        async fn find_by_email(
-            &self,
-            email: &EmailAddress,
-        ) -> Result<Option<IdentityLink>, RepositoryError> {
-            Ok(self.links.lock().unwrap().get(email.as_str()).cloned())
-        }
-
-        async fn find_by_external_user_id(
-            &self,
-            system: &ExternalSystem,
-            user_id: &str,
-        ) -> Result<Option<IdentityLink>, RepositoryError> {
-            let links = self.links.lock().unwrap();
-            let found = links.values().find(|link| {
-                link.get_identity_for_system(system)
-                    .is_some_and(|identity| identity.user_id() == user_id)
-            });
-            Ok(found.cloned())
-        }
-
-        async fn save(&self, identity_link: IdentityLink) -> Result<(), RepositoryError> {
-            self.links
-                .lock()
-                .unwrap()
-                .insert(identity_link.email().as_str().to_string(), identity_link);
-            Ok(())
-        }
-    }
-
-    #[derive(Clone, Default)]
-    struct RecordingUnauthorizedUsageNotifier {
-        notified: Arc<StdMutex<Vec<(ResourceUsage, EmailAddress)>>>,
-    }
-
-    impl RecordingUnauthorizedUsageNotifier {
-        fn notified(&self) -> Vec<(ResourceUsage, EmailAddress)> {
-            self.notified.lock().unwrap().clone()
-        }
-    }
-
-    #[async_trait]
-    impl UnauthorizedUsageNotifier for RecordingUnauthorizedUsageNotifier {
-        async fn notify(
-            &self,
-            reserved_usage: &ResourceUsage,
-            actual_user_email: &EmailAddress,
-        ) -> Result<(), NotificationError> {
-            self.notified
-                .lock()
-                .unwrap()
-                .push((reserved_usage.clone(), actual_user_email.clone()));
-            Ok(())
-        }
-    }
-
-    /// 指定したメールアドレス宛の提案だけを失敗させられるテスト用ダブル
-    #[derive(Clone, Default)]
-    struct FailingReservationProposalNotifier {
-        fail_for_emails: Arc<StdMutex<HashSet<String>>>,
-        succeeded_emails: Arc<StdMutex<Vec<String>>>,
-        call_count: Arc<StdMutex<u32>>,
-    }
-
-    impl FailingReservationProposalNotifier {
-        fn new() -> Self {
-            Self::default()
-        }
-
-        fn fail_for(&self, email: &str) {
-            self.fail_for_emails
-                .lock()
-                .unwrap()
-                .insert(email.to_string());
-        }
-
-        fn allow(&self, email: &str) {
-            self.fail_for_emails.lock().unwrap().remove(email);
-        }
-
-        fn call_count(&self) -> u32 {
-            *self.call_count.lock().unwrap()
-        }
-
-        fn succeeded_emails(&self) -> Vec<String> {
-            self.succeeded_emails.lock().unwrap().clone()
-        }
-    }
-
-    #[async_trait]
-    impl ReservationProposalNotifier for FailingReservationProposalNotifier {
-        async fn propose(&self, proposal: ReservationProposal) -> Result<(), NotificationError> {
-            *self.call_count.lock().unwrap() += 1;
-            let email = proposal.owner_email().as_str().to_string();
-            if self.fail_for_emails.lock().unwrap().contains(&email) {
-                return Err(NotificationError::SendFailure(
-                    "test induced failure".to_string(),
-                ));
-            }
-            self.succeeded_emails.lock().unwrap().push(email);
-            Ok(())
-        }
-    }
-
-    fn gpu_resource() -> Resource {
-        Resource::Gpu(Gpu::new("Thalys".to_string(), 0, "A100".to_string()))
-    }
-
-    fn gpu_resource_device1() -> Resource {
-        Resource::Gpu(Gpu::new("Thalys".to_string(), 1, "A100".to_string()))
-    }
-
-    /// gpu_resource()と同じサーバー("Thalys")に紐づくOS識別子
-    fn os_system() -> ExternalSystem {
-        ExternalSystem::Os {
-            server: "Thalys".to_string(),
-        }
-    }
-
-    fn make_reservation(
-        owner_email: &str,
-        start: DateTime<Utc>,
-        end: DateTime<Utc>,
-    ) -> ResourceUsage {
-        let email = EmailAddress::new(owner_email.to_string()).unwrap();
-        let period = TimePeriod::new(start, end).unwrap();
-        ResourceUsage::new(email, period, vec![gpu_resource()], None).unwrap()
-    }
-
-    #[allow(clippy::type_complexity)]
-    fn make_usecase(
-        threshold_minutes: i64,
-    ) -> (
-        ReconcileObservedUsagesUseCase<
-            MockUsageRepository,
-            MockResourceUsageObserver,
-            InMemoryIdentityLinkRepository,
-            MockReservationProposalNotifier,
-            RecordingUnauthorizedUsageNotifier,
-        >,
-        Arc<MockUsageRepository>,
-        Arc<MockResourceUsageObserver>,
-        Arc<InMemoryIdentityLinkRepository>,
-        MockReservationProposalNotifier,
-        RecordingUnauthorizedUsageNotifier,
-    ) {
-        let repository = Arc::new(MockUsageRepository::new());
-        let observer = Arc::new(MockResourceUsageObserver::new());
-        let identity_repo = Arc::new(InMemoryIdentityLinkRepository::default());
-        let proposal_notifier = MockReservationProposalNotifier::new();
-        let notifier = RecordingUnauthorizedUsageNotifier::default();
-
-        let usecase = ReconcileObservedUsagesUseCase::new(
-            repository.clone(),
-            observer.clone(),
-            identity_repo.clone(),
-            proposal_notifier.clone(),
-            notifier.clone(),
-            Duration::minutes(threshold_minutes),
-            vec![Duration::hours(1), Duration::hours(2), Duration::hours(3)],
-        );
-
-        (
-            usecase,
-            repository,
-            observer,
-            identity_repo,
-            proposal_notifier,
-            notifier,
-        )
-    }
-
-    #[allow(clippy::type_complexity)]
-    fn make_usecase_with_failing_notifier(
-        threshold_minutes: i64,
-    ) -> (
-        ReconcileObservedUsagesUseCase<
-            MockUsageRepository,
-            MockResourceUsageObserver,
-            InMemoryIdentityLinkRepository,
-            FailingReservationProposalNotifier,
-            RecordingUnauthorizedUsageNotifier,
-        >,
-        Arc<MockResourceUsageObserver>,
-        Arc<InMemoryIdentityLinkRepository>,
-        FailingReservationProposalNotifier,
-    ) {
-        let repository = Arc::new(MockUsageRepository::new());
-        let observer = Arc::new(MockResourceUsageObserver::new());
-        let identity_repo = Arc::new(InMemoryIdentityLinkRepository::default());
-        let proposal_notifier = FailingReservationProposalNotifier::new();
-        let notifier = RecordingUnauthorizedUsageNotifier::default();
-
-        let usecase = ReconcileObservedUsagesUseCase::new(
-            repository,
-            observer.clone(),
-            identity_repo.clone(),
-            proposal_notifier.clone(),
-            notifier,
-            Duration::minutes(threshold_minutes),
-            vec![Duration::hours(1), Duration::hours(2), Duration::hours(3)],
-        );
-
-        (usecase, observer, identity_repo, proposal_notifier)
-    }
-
-    #[tokio::test]
-    async fn test_below_threshold_does_not_propose() {
-        let (usecase, _repo, observer, identity_repo, proposal_notifier, _notifier) =
-            make_usecase(15);
-        identity_repo.add_link("user@example.com", os_system(), "kkawaguchi");
-
-        let now = Utc::now();
-        observer.set_active_usages(vec![ObservedUsage::new(
-            gpu_resource(),
-            ExternalIdentity::new(os_system(), "kkawaguchi".to_string()),
-            now - Duration::minutes(5),
-        )]);
-
-        usecase.poll_once().await.unwrap();
-
-        assert!(proposal_notifier.sent_proposals().is_empty());
-    }
-
-    #[tokio::test]
-    async fn test_unreserved_past_threshold_proposes_once() {
-        let (usecase, _repo, observer, identity_repo, proposal_notifier, _notifier) =
-            make_usecase(15);
-        identity_repo.add_link("user@example.com", os_system(), "kkawaguchi");
-
-        let active_since = Utc::now() - Duration::minutes(20);
-        observer.set_active_usages(vec![ObservedUsage::new(
-            gpu_resource(),
-            ExternalIdentity::new(os_system(), "kkawaguchi".to_string()),
-            active_since,
-        )]);
-
-        usecase.poll_once().await.unwrap();
-        usecase.poll_once().await.unwrap();
-
-        let proposals = proposal_notifier.sent_proposals();
-        assert_eq!(proposals.len(), 1);
-        assert_eq!(proposals[0].owner_email().as_str(), "user@example.com");
-        assert_eq!(proposals[0].duration_candidates().len(), 3);
-    }
-
-    #[tokio::test]
-    async fn test_unlinked_user_does_not_propose() {
-        let (usecase, _repo, observer, _identity_repo, proposal_notifier, _notifier) =
-            make_usecase(15);
-
-        let active_since = Utc::now() - Duration::minutes(20);
-        observer.set_active_usages(vec![ObservedUsage::new(
-            gpu_resource(),
-            ExternalIdentity::new(os_system(), "unknown".to_string()),
-            active_since,
-        )]);
-
-        usecase.poll_once().await.unwrap();
-
-        assert!(proposal_notifier.sent_proposals().is_empty());
-    }
-
-    #[tokio::test]
-    async fn test_reserved_matching_owner_no_notification() {
-        let (usecase, repo, observer, identity_repo, proposal_notifier, notifier) =
-            make_usecase(15);
-        identity_repo.add_link("owner@example.com", os_system(), "kkawaguchi");
-
-        let now = Utc::now();
-        let reservation = make_reservation(
-            "owner@example.com",
-            now - Duration::hours(1),
-            now + Duration::hours(1),
-        );
-        repo.save(&reservation).await.unwrap();
-
-        observer.set_active_usages(vec![ObservedUsage::new(
-            gpu_resource(),
-            ExternalIdentity::new(os_system(), "kkawaguchi".to_string()),
-            now - Duration::minutes(30),
-        )]);
-
-        usecase.poll_once().await.unwrap();
-
-        assert!(notifier.notified().is_empty());
-        assert!(proposal_notifier.sent_proposals().is_empty());
-    }
-
-    #[tokio::test]
-    async fn test_reserved_mismatched_owner_notifies_unauthorized() {
-        let (usecase, repo, observer, identity_repo, proposal_notifier, notifier) =
-            make_usecase(15);
-        identity_repo.add_link("other@example.com", os_system(), "kkawaguchi");
-
-        let now = Utc::now();
-        let reservation = make_reservation(
-            "owner@example.com",
-            now - Duration::hours(1),
-            now + Duration::hours(1),
-        );
-        repo.save(&reservation).await.unwrap();
-
-        observer.set_active_usages(vec![ObservedUsage::new(
-            gpu_resource(),
-            ExternalIdentity::new(os_system(), "kkawaguchi".to_string()),
-            now - Duration::minutes(30),
-        )]);
-
-        usecase.poll_once().await.unwrap();
-
-        let notified = notifier.notified();
-        assert_eq!(notified.len(), 1);
-        let (reserved_usage, actual_user_email) = &notified[0];
-        assert_eq!(reserved_usage.owner_email().as_str(), "owner@example.com");
-        assert_eq!(actual_user_email.as_str(), "other@example.com");
-
-        // 未予約提案は発生しない（既に予約が存在するため）
-        assert!(proposal_notifier.sent_proposals().is_empty());
-    }
-
-    #[tokio::test]
-    async fn test_unauthorized_notification_deduplicated_per_observation_session() {
-        let (usecase, repo, observer, identity_repo, _proposal_notifier, notifier) =
-            make_usecase(15);
-        identity_repo.add_link("other@example.com", os_system(), "kkawaguchi");
-
-        let now = Utc::now();
-        let reservation = make_reservation(
-            "owner@example.com",
-            now - Duration::hours(1),
-            now + Duration::hours(1),
-        );
-        repo.save(&reservation).await.unwrap();
-
-        let active_since = now - Duration::minutes(30);
-        observer.set_active_usages(vec![ObservedUsage::new(
-            gpu_resource(),
-            ExternalIdentity::new(os_system(), "kkawaguchi".to_string()),
-            active_since,
-        )]);
-
-        // 同一の観測セッションが続く限り、何度ポーリングしても通知は1回だけ
-        usecase.poll_once().await.unwrap();
-        usecase.poll_once().await.unwrap();
-        usecase.poll_once().await.unwrap();
-        assert_eq!(notifier.notified().len(), 1);
-
-        // プロセスが入れ替わる（観測開始時刻が変わる）と新しいセッションとして再通知する
-        observer.set_active_usages(vec![ObservedUsage::new(
-            gpu_resource(),
-            ExternalIdentity::new(os_system(), "kkawaguchi".to_string()),
-            active_since + Duration::minutes(10),
-        )]);
-        usecase.poll_once().await.unwrap();
-        assert_eq!(notifier.notified().len(), 2);
-    }
-
-    #[tokio::test]
-    async fn test_reserved_unknown_identity_skips_notification() {
-        let (usecase, repo, observer, _identity_repo, proposal_notifier, notifier) =
-            make_usecase(15);
-        // 誰にもリンクされていないOS識別子（IdentityLink未登録）
-
-        let now = Utc::now();
-        let reservation = make_reservation(
-            "owner@example.com",
-            now - Duration::hours(1),
-            now + Duration::hours(1),
-        );
-        repo.save(&reservation).await.unwrap();
-
-        observer.set_active_usages(vec![ObservedUsage::new(
-            gpu_resource(),
-            ExternalIdentity::new(os_system(), "unknown".to_string()),
-            now - Duration::minutes(30),
-        )]);
-
-        usecase.poll_once().await.unwrap();
-
-        // 利用者の身元が不明なため、無断使用かどうか原理的に判定できずスキップされる
-        assert!(notifier.notified().is_empty());
-        assert!(proposal_notifier.sent_proposals().is_empty());
-    }
-
-    #[tokio::test]
-    async fn test_propose_failure_allows_retry_on_next_poll() {
-        let (usecase, observer, identity_repo, proposal_notifier) =
-            make_usecase_with_failing_notifier(15);
-        identity_repo.add_link("user@example.com", os_system(), "kkawaguchi");
-        proposal_notifier.fail_for("user@example.com");
-
-        let active_since = Utc::now() - Duration::minutes(20);
-        observer.set_active_usages(vec![ObservedUsage::new(
-            gpu_resource(),
-            ExternalIdentity::new(os_system(), "kkawaguchi".to_string()),
-            active_since,
-        )]);
-
-        // 1回目: propose()が失敗する→「提案済み」として記録されない
-        usecase.poll_once().await.unwrap();
-        assert_eq!(proposal_notifier.call_count(), 1);
-        assert!(proposal_notifier.succeeded_emails().is_empty());
-
-        // 2回目: 送信が成功するようにしてから再度ポーリング→再試行される
-        proposal_notifier.allow("user@example.com");
-        usecase.poll_once().await.unwrap();
-        assert_eq!(proposal_notifier.call_count(), 2);
-        assert_eq!(
-            proposal_notifier.succeeded_emails(),
-            vec!["user@example.com".to_string()]
-        );
-    }
-
-    #[tokio::test]
-    async fn test_one_failure_does_not_block_other_usages() {
-        let (usecase, observer, identity_repo, proposal_notifier) =
-            make_usecase_with_failing_notifier(15);
-        identity_repo.add_link("userA@example.com", os_system(), "kkawaguchiA");
-        identity_repo.add_link("userB@example.com", os_system(), "kkawaguchiB");
-        proposal_notifier.fail_for("userA@example.com");
-
-        let active_since = Utc::now() - Duration::minutes(20);
-        observer.set_active_usages(vec![
-            ObservedUsage::new(
-                gpu_resource(),
-                ExternalIdentity::new(os_system(), "kkawaguchiA".to_string()),
-                active_since,
-            ),
-            ObservedUsage::new(
-                gpu_resource_device1(),
-                ExternalIdentity::new(os_system(), "kkawaguchiB".to_string()),
-                active_since,
-            ),
-        ]);
-
-        usecase.poll_once().await.unwrap();
-
-        assert_eq!(proposal_notifier.call_count(), 2);
-        assert_eq!(
-            proposal_notifier.succeeded_emails(),
-            vec!["userB@example.com".to_string()]
-        );
     }
 }

--- a/src/application/usecases/reconcile_observed_usages_tests.rs
+++ b/src/application/usecases/reconcile_observed_usages_tests.rs
@@ -1,0 +1,620 @@
+//! `ReconcileObservedUsagesUseCase`のテスト
+//!
+//! 実利用と予約の突合、無断使用の通知、事後予約提案のまとめ方を検証する。
+
+use crate::application::usecases::reconcile_observed_usages::ReconcileObservedUsagesUseCase;
+use crate::domain::aggregates::identity_link::{
+    entity::IdentityLink,
+    value_objects::{ExternalIdentity, ExternalSystem},
+};
+use crate::domain::aggregates::resource_usage::entity::ResourceUsage;
+use crate::domain::aggregates::resource_usage::value_objects::{Gpu, Resource, TimePeriod};
+use crate::domain::common::EmailAddress;
+use crate::domain::ports::repositories::{
+    IdentityLinkRepository, RepositoryError, ResourceUsageRepository,
+};
+use crate::domain::ports::{
+    NotificationError, ObservedUsage, ReservationProposal, ReservationProposalNotifier,
+    UnauthorizedUsageNotifier,
+};
+use crate::infrastructure::repositories::resource_usage::mock::MockUsageRepository;
+use crate::infrastructure::reservation_proposal::MockReservationProposalNotifier;
+use crate::infrastructure::resource_usage_observer::MockResourceUsageObserver;
+use async_trait::async_trait;
+use chrono::{DateTime, Duration, Utc};
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
+
+#[derive(Default)]
+struct InMemoryIdentityLinkRepository {
+    links: StdMutex<HashMap<String, IdentityLink>>,
+}
+
+impl InMemoryIdentityLinkRepository {
+    fn add_link(&self, email: &str, system: ExternalSystem, user_id: &str) {
+        let email_addr = EmailAddress::new(email.to_string()).unwrap();
+        let identity = ExternalIdentity::new(system, user_id.to_string());
+        let link = IdentityLink::with_external_identity(email_addr.clone(), identity);
+        self.links
+            .lock()
+            .unwrap()
+            .insert(email_addr.as_str().to_string(), link);
+    }
+}
+
+#[async_trait]
+impl IdentityLinkRepository for InMemoryIdentityLinkRepository {
+    async fn find_by_email(
+        &self,
+        email: &EmailAddress,
+    ) -> Result<Option<IdentityLink>, RepositoryError> {
+        Ok(self.links.lock().unwrap().get(email.as_str()).cloned())
+    }
+
+    async fn find_by_external_user_id(
+        &self,
+        system: &ExternalSystem,
+        user_id: &str,
+    ) -> Result<Option<IdentityLink>, RepositoryError> {
+        let links = self.links.lock().unwrap();
+        let found = links.values().find(|link| {
+            link.get_identity_for_system(system)
+                .is_some_and(|identity| identity.user_id() == user_id)
+        });
+        Ok(found.cloned())
+    }
+
+    async fn save(&self, identity_link: IdentityLink) -> Result<(), RepositoryError> {
+        self.links
+            .lock()
+            .unwrap()
+            .insert(identity_link.email().as_str().to_string(), identity_link);
+        Ok(())
+    }
+}
+
+#[derive(Clone, Default)]
+struct RecordingUnauthorizedUsageNotifier {
+    notified: Arc<StdMutex<Vec<(ResourceUsage, EmailAddress)>>>,
+}
+
+impl RecordingUnauthorizedUsageNotifier {
+    fn notified(&self) -> Vec<(ResourceUsage, EmailAddress)> {
+        self.notified.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl UnauthorizedUsageNotifier for RecordingUnauthorizedUsageNotifier {
+    async fn notify(
+        &self,
+        reserved_usage: &ResourceUsage,
+        actual_user_email: &EmailAddress,
+    ) -> Result<(), NotificationError> {
+        self.notified
+            .lock()
+            .unwrap()
+            .push((reserved_usage.clone(), actual_user_email.clone()));
+        Ok(())
+    }
+}
+
+/// 指定したメールアドレス宛の提案だけを失敗させられるテスト用ダブル
+#[derive(Clone, Default)]
+struct FailingReservationProposalNotifier {
+    fail_for_emails: Arc<StdMutex<HashSet<String>>>,
+    succeeded_emails: Arc<StdMutex<Vec<String>>>,
+    call_count: Arc<StdMutex<u32>>,
+}
+
+impl FailingReservationProposalNotifier {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn fail_for(&self, email: &str) {
+        self.fail_for_emails
+            .lock()
+            .unwrap()
+            .insert(email.to_string());
+    }
+
+    fn allow(&self, email: &str) {
+        self.fail_for_emails.lock().unwrap().remove(email);
+    }
+
+    fn call_count(&self) -> u32 {
+        *self.call_count.lock().unwrap()
+    }
+
+    fn succeeded_emails(&self) -> Vec<String> {
+        self.succeeded_emails.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl ReservationProposalNotifier for FailingReservationProposalNotifier {
+    async fn propose(&self, proposal: ReservationProposal) -> Result<(), NotificationError> {
+        *self.call_count.lock().unwrap() += 1;
+        let email = proposal.owner_email().as_str().to_string();
+        if self.fail_for_emails.lock().unwrap().contains(&email) {
+            return Err(NotificationError::SendFailure(
+                "test induced failure".to_string(),
+            ));
+        }
+        self.succeeded_emails.lock().unwrap().push(email);
+        Ok(())
+    }
+}
+
+fn gpu_resource() -> Resource {
+    Resource::Gpu(Gpu::new("Thalys".to_string(), 0, "A100".to_string()))
+}
+
+fn gpu_resource_device1() -> Resource {
+    Resource::Gpu(Gpu::new("Thalys".to_string(), 1, "A100".to_string()))
+}
+
+fn gpu_resource_device2() -> Resource {
+    Resource::Gpu(Gpu::new("Thalys".to_string(), 2, "A100".to_string()))
+}
+
+/// gpu_resource()と同じサーバー("Thalys")に紐づくOS識別子
+fn os_system() -> ExternalSystem {
+    ExternalSystem::Os {
+        server: "Thalys".to_string(),
+    }
+}
+
+fn make_reservation(owner_email: &str, start: DateTime<Utc>, end: DateTime<Utc>) -> ResourceUsage {
+    let email = EmailAddress::new(owner_email.to_string()).unwrap();
+    let period = TimePeriod::new(start, end).unwrap();
+    ResourceUsage::new(email, period, vec![gpu_resource()], None).unwrap()
+}
+
+#[allow(clippy::type_complexity)]
+fn make_usecase(
+    threshold_minutes: i64,
+) -> (
+    ReconcileObservedUsagesUseCase<
+        MockUsageRepository,
+        MockResourceUsageObserver,
+        InMemoryIdentityLinkRepository,
+        MockReservationProposalNotifier,
+        RecordingUnauthorizedUsageNotifier,
+    >,
+    Arc<MockUsageRepository>,
+    Arc<MockResourceUsageObserver>,
+    Arc<InMemoryIdentityLinkRepository>,
+    MockReservationProposalNotifier,
+    RecordingUnauthorizedUsageNotifier,
+) {
+    let repository = Arc::new(MockUsageRepository::new());
+    let observer = Arc::new(MockResourceUsageObserver::new());
+    let identity_repo = Arc::new(InMemoryIdentityLinkRepository::default());
+    let proposal_notifier = MockReservationProposalNotifier::new();
+    let notifier = RecordingUnauthorizedUsageNotifier::default();
+
+    let usecase = ReconcileObservedUsagesUseCase::new(
+        repository.clone(),
+        observer.clone(),
+        identity_repo.clone(),
+        proposal_notifier.clone(),
+        notifier.clone(),
+        Duration::minutes(threshold_minutes),
+        vec![Duration::hours(1), Duration::hours(2), Duration::hours(3)],
+    );
+
+    (
+        usecase,
+        repository,
+        observer,
+        identity_repo,
+        proposal_notifier,
+        notifier,
+    )
+}
+
+#[allow(clippy::type_complexity)]
+fn make_usecase_with_failing_notifier(
+    threshold_minutes: i64,
+) -> (
+    ReconcileObservedUsagesUseCase<
+        MockUsageRepository,
+        MockResourceUsageObserver,
+        InMemoryIdentityLinkRepository,
+        FailingReservationProposalNotifier,
+        RecordingUnauthorizedUsageNotifier,
+    >,
+    Arc<MockResourceUsageObserver>,
+    Arc<InMemoryIdentityLinkRepository>,
+    FailingReservationProposalNotifier,
+) {
+    let repository = Arc::new(MockUsageRepository::new());
+    let observer = Arc::new(MockResourceUsageObserver::new());
+    let identity_repo = Arc::new(InMemoryIdentityLinkRepository::default());
+    let proposal_notifier = FailingReservationProposalNotifier::new();
+    let notifier = RecordingUnauthorizedUsageNotifier::default();
+
+    let usecase = ReconcileObservedUsagesUseCase::new(
+        repository,
+        observer.clone(),
+        identity_repo.clone(),
+        proposal_notifier.clone(),
+        notifier,
+        Duration::minutes(threshold_minutes),
+        vec![Duration::hours(1), Duration::hours(2), Duration::hours(3)],
+    );
+
+    (usecase, observer, identity_repo, proposal_notifier)
+}
+
+#[tokio::test]
+async fn test_below_threshold_does_not_propose() {
+    let (usecase, _repo, observer, identity_repo, proposal_notifier, _notifier) = make_usecase(15);
+    identity_repo.add_link("user@example.com", os_system(), "kkawaguchi");
+
+    let now = Utc::now();
+    observer.set_active_usages(vec![ObservedUsage::new(
+        gpu_resource(),
+        ExternalIdentity::new(os_system(), "kkawaguchi".to_string()),
+        now - Duration::minutes(5),
+    )]);
+
+    usecase.poll_once().await.unwrap();
+
+    assert!(proposal_notifier.sent_proposals().is_empty());
+}
+
+#[tokio::test]
+async fn test_unreserved_past_threshold_proposes_once() {
+    let (usecase, _repo, observer, identity_repo, proposal_notifier, _notifier) = make_usecase(15);
+    identity_repo.add_link("user@example.com", os_system(), "kkawaguchi");
+
+    let active_since = Utc::now() - Duration::minutes(20);
+    observer.set_active_usages(vec![ObservedUsage::new(
+        gpu_resource(),
+        ExternalIdentity::new(os_system(), "kkawaguchi".to_string()),
+        active_since,
+    )]);
+
+    usecase.poll_once().await.unwrap();
+    usecase.poll_once().await.unwrap();
+
+    let proposals = proposal_notifier.sent_proposals();
+    assert_eq!(proposals.len(), 1);
+    assert_eq!(proposals[0].owner_email().as_str(), "user@example.com");
+    assert_eq!(proposals[0].duration_candidates().len(), 3);
+}
+
+#[tokio::test]
+async fn test_unlinked_user_does_not_propose() {
+    let (usecase, _repo, observer, _identity_repo, proposal_notifier, _notifier) = make_usecase(15);
+
+    let active_since = Utc::now() - Duration::minutes(20);
+    observer.set_active_usages(vec![ObservedUsage::new(
+        gpu_resource(),
+        ExternalIdentity::new(os_system(), "unknown".to_string()),
+        active_since,
+    )]);
+
+    usecase.poll_once().await.unwrap();
+
+    assert!(proposal_notifier.sent_proposals().is_empty());
+}
+
+#[tokio::test]
+async fn test_reserved_matching_owner_no_notification() {
+    let (usecase, repo, observer, identity_repo, proposal_notifier, notifier) = make_usecase(15);
+    identity_repo.add_link("owner@example.com", os_system(), "kkawaguchi");
+
+    let now = Utc::now();
+    let reservation = make_reservation(
+        "owner@example.com",
+        now - Duration::hours(1),
+        now + Duration::hours(1),
+    );
+    repo.save(&reservation).await.unwrap();
+
+    observer.set_active_usages(vec![ObservedUsage::new(
+        gpu_resource(),
+        ExternalIdentity::new(os_system(), "kkawaguchi".to_string()),
+        now - Duration::minutes(30),
+    )]);
+
+    usecase.poll_once().await.unwrap();
+
+    assert!(notifier.notified().is_empty());
+    assert!(proposal_notifier.sent_proposals().is_empty());
+}
+
+#[tokio::test]
+async fn test_reserved_mismatched_owner_notifies_unauthorized() {
+    let (usecase, repo, observer, identity_repo, proposal_notifier, notifier) = make_usecase(15);
+    identity_repo.add_link("other@example.com", os_system(), "kkawaguchi");
+
+    let now = Utc::now();
+    let reservation = make_reservation(
+        "owner@example.com",
+        now - Duration::hours(1),
+        now + Duration::hours(1),
+    );
+    repo.save(&reservation).await.unwrap();
+
+    observer.set_active_usages(vec![ObservedUsage::new(
+        gpu_resource(),
+        ExternalIdentity::new(os_system(), "kkawaguchi".to_string()),
+        now - Duration::minutes(30),
+    )]);
+
+    usecase.poll_once().await.unwrap();
+
+    let notified = notifier.notified();
+    assert_eq!(notified.len(), 1);
+    let (reserved_usage, actual_user_email) = &notified[0];
+    assert_eq!(reserved_usage.owner_email().as_str(), "owner@example.com");
+    assert_eq!(actual_user_email.as_str(), "other@example.com");
+
+    // 未予約提案は発生しない（既に予約が存在するため）
+    assert!(proposal_notifier.sent_proposals().is_empty());
+}
+
+#[tokio::test]
+async fn test_unauthorized_notification_deduplicated_per_observation_session() {
+    let (usecase, repo, observer, identity_repo, _proposal_notifier, notifier) = make_usecase(15);
+    identity_repo.add_link("other@example.com", os_system(), "kkawaguchi");
+
+    let now = Utc::now();
+    let reservation = make_reservation(
+        "owner@example.com",
+        now - Duration::hours(1),
+        now + Duration::hours(1),
+    );
+    repo.save(&reservation).await.unwrap();
+
+    let active_since = now - Duration::minutes(30);
+    observer.set_active_usages(vec![ObservedUsage::new(
+        gpu_resource(),
+        ExternalIdentity::new(os_system(), "kkawaguchi".to_string()),
+        active_since,
+    )]);
+
+    // 同一の観測セッションが続く限り、何度ポーリングしても通知は1回だけ
+    usecase.poll_once().await.unwrap();
+    usecase.poll_once().await.unwrap();
+    usecase.poll_once().await.unwrap();
+    assert_eq!(notifier.notified().len(), 1);
+
+    // プロセスが入れ替わる（観測開始時刻が変わる）と新しいセッションとして再通知する
+    observer.set_active_usages(vec![ObservedUsage::new(
+        gpu_resource(),
+        ExternalIdentity::new(os_system(), "kkawaguchi".to_string()),
+        active_since + Duration::minutes(10),
+    )]);
+    usecase.poll_once().await.unwrap();
+    assert_eq!(notifier.notified().len(), 2);
+}
+
+#[tokio::test]
+async fn test_reserved_unknown_identity_skips_notification() {
+    let (usecase, repo, observer, _identity_repo, proposal_notifier, notifier) = make_usecase(15);
+    // 誰にもリンクされていないOS識別子（IdentityLink未登録）
+
+    let now = Utc::now();
+    let reservation = make_reservation(
+        "owner@example.com",
+        now - Duration::hours(1),
+        now + Duration::hours(1),
+    );
+    repo.save(&reservation).await.unwrap();
+
+    observer.set_active_usages(vec![ObservedUsage::new(
+        gpu_resource(),
+        ExternalIdentity::new(os_system(), "unknown".to_string()),
+        now - Duration::minutes(30),
+    )]);
+
+    usecase.poll_once().await.unwrap();
+
+    // 利用者の身元が不明なため、無断使用かどうか原理的に判定できずスキップされる
+    assert!(notifier.notified().is_empty());
+    assert!(proposal_notifier.sent_proposals().is_empty());
+}
+
+#[tokio::test]
+async fn test_propose_failure_allows_retry_on_next_poll() {
+    let (usecase, observer, identity_repo, proposal_notifier) =
+        make_usecase_with_failing_notifier(15);
+    identity_repo.add_link("user@example.com", os_system(), "kkawaguchi");
+    proposal_notifier.fail_for("user@example.com");
+
+    let active_since = Utc::now() - Duration::minutes(20);
+    observer.set_active_usages(vec![ObservedUsage::new(
+        gpu_resource(),
+        ExternalIdentity::new(os_system(), "kkawaguchi".to_string()),
+        active_since,
+    )]);
+
+    // 1回目: propose()が失敗する→「提案済み」として記録されない
+    usecase.poll_once().await.unwrap();
+    assert_eq!(proposal_notifier.call_count(), 1);
+    assert!(proposal_notifier.succeeded_emails().is_empty());
+
+    // 2回目: 送信が成功するようにしてから再度ポーリング→再試行される
+    proposal_notifier.allow("user@example.com");
+    usecase.poll_once().await.unwrap();
+    assert_eq!(proposal_notifier.call_count(), 2);
+    assert_eq!(
+        proposal_notifier.succeeded_emails(),
+        vec!["user@example.com".to_string()]
+    );
+}
+
+#[tokio::test]
+async fn test_one_failure_does_not_block_other_usages() {
+    let (usecase, observer, identity_repo, proposal_notifier) =
+        make_usecase_with_failing_notifier(15);
+    identity_repo.add_link("userA@example.com", os_system(), "kkawaguchiA");
+    identity_repo.add_link("userB@example.com", os_system(), "kkawaguchiB");
+    proposal_notifier.fail_for("userA@example.com");
+
+    let active_since = Utc::now() - Duration::minutes(20);
+    observer.set_active_usages(vec![
+        ObservedUsage::new(
+            gpu_resource(),
+            ExternalIdentity::new(os_system(), "kkawaguchiA".to_string()),
+            active_since,
+        ),
+        ObservedUsage::new(
+            gpu_resource_device1(),
+            ExternalIdentity::new(os_system(), "kkawaguchiB".to_string()),
+            active_since,
+        ),
+    ]);
+
+    usecase.poll_once().await.unwrap();
+
+    assert_eq!(proposal_notifier.call_count(), 2);
+    assert_eq!(
+        proposal_notifier.succeeded_emails(),
+        vec!["userB@example.com".to_string()]
+    );
+}
+#[tokio::test]
+async fn test_same_user_starting_several_gpus_gets_one_proposal() {
+    let (usecase, _repo, observer, identity_repo, proposal_notifier, _notifier) = make_usecase(15);
+    identity_repo.add_link("user@example.com", os_system(), "kkawaguchi");
+
+    // 3枚を続けて使い始めると、観測開始時刻は秒単位でずれる
+    let active_since = Utc::now() - Duration::minutes(20);
+    observer.set_active_usages(vec![
+        ObservedUsage::new(
+            gpu_resource(),
+            ExternalIdentity::new(os_system(), "kkawaguchi".to_string()),
+            active_since,
+        ),
+        ObservedUsage::new(
+            gpu_resource_device1(),
+            ExternalIdentity::new(os_system(), "kkawaguchi".to_string()),
+            active_since + Duration::seconds(3),
+        ),
+        ObservedUsage::new(
+            gpu_resource_device2(),
+            ExternalIdentity::new(os_system(), "kkawaguchi".to_string()),
+            active_since + Duration::seconds(9),
+        ),
+    ]);
+
+    usecase.poll_once().await.unwrap();
+
+    let proposals = proposal_notifier.sent_proposals();
+    assert_eq!(proposals.len(), 1, "枚数分の提案に分かれてはいけない");
+    assert_eq!(
+        proposals[0].resources().len(),
+        3,
+        "3枚が1件の提案にまとまるべき"
+    );
+    assert_eq!(
+        proposals[0].active_since(),
+        active_since,
+        "利用開始時刻はグループ内で最も早い時刻を使うべき"
+    );
+}
+
+#[tokio::test]
+async fn test_usages_far_apart_in_time_are_proposed_separately() {
+    let (usecase, _repo, observer, identity_repo, proposal_notifier, _notifier) = make_usecase(15);
+    identity_repo.add_link("user@example.com", os_system(), "kkawaguchi");
+
+    let now = Utc::now();
+    observer.set_active_usages(vec![
+        ObservedUsage::new(
+            gpu_resource(),
+            ExternalIdentity::new(os_system(), "kkawaguchi".to_string()),
+            now - Duration::minutes(40),
+        ),
+        // 30分後に別の作業として使い始めた分は、別の機会として扱う
+        ObservedUsage::new(
+            gpu_resource_device1(),
+            ExternalIdentity::new(os_system(), "kkawaguchi".to_string()),
+            now - Duration::minutes(20),
+        ),
+    ]);
+
+    usecase.poll_once().await.unwrap();
+
+    assert_eq!(
+        proposal_notifier.sent_proposals().len(),
+        2,
+        "離れた時刻の利用は別の提案になるべき"
+    );
+}
+
+#[tokio::test]
+async fn test_reserved_resource_is_excluded_from_the_grouped_proposal() {
+    let (usecase, repo, observer, identity_repo, proposal_notifier, _notifier) = make_usecase(15);
+    identity_repo.add_link("user@example.com", os_system(), "kkawaguchi");
+
+    // GPU:0 は予約済み（提案対象外）、GPU:1 は未予約
+    let now = Utc::now();
+    let reservation = make_reservation(
+        "user@example.com",
+        now - Duration::hours(1),
+        now + Duration::hours(1),
+    );
+    repo.save(&reservation).await.unwrap();
+
+    let active_since = now - Duration::minutes(20);
+    observer.set_active_usages(vec![
+        ObservedUsage::new(
+            gpu_resource(),
+            ExternalIdentity::new(os_system(), "kkawaguchi".to_string()),
+            active_since,
+        ),
+        ObservedUsage::new(
+            gpu_resource_device1(),
+            ExternalIdentity::new(os_system(), "kkawaguchi".to_string()),
+            active_since,
+        ),
+    ]);
+
+    usecase.poll_once().await.unwrap();
+
+    let proposals = proposal_notifier.sent_proposals();
+    assert_eq!(proposals.len(), 1);
+    assert_eq!(
+        proposals[0].resources(),
+        &[gpu_resource_device1()],
+        "予約済みのリソースは提案に含めない"
+    );
+}
+
+#[tokio::test]
+async fn test_grouped_proposal_is_sent_only_once_per_session() {
+    let (usecase, _repo, observer, identity_repo, proposal_notifier, _notifier) = make_usecase(15);
+    identity_repo.add_link("user@example.com", os_system(), "kkawaguchi");
+
+    let active_since = Utc::now() - Duration::minutes(20);
+    observer.set_active_usages(vec![
+        ObservedUsage::new(
+            gpu_resource(),
+            ExternalIdentity::new(os_system(), "kkawaguchi".to_string()),
+            active_since,
+        ),
+        ObservedUsage::new(
+            gpu_resource_device1(),
+            ExternalIdentity::new(os_system(), "kkawaguchi".to_string()),
+            active_since,
+        ),
+    ]);
+
+    usecase.poll_once().await.unwrap();
+    usecase.poll_once().await.unwrap();
+
+    assert_eq!(
+        proposal_notifier.sent_proposals().len(),
+        1,
+        "同じ観測セッションへの提案は一度だけ"
+    );
+}

--- a/src/bin/lab-resource-manager.rs
+++ b/src/bin/lab-resource-manager.rs
@@ -7,6 +7,7 @@ use axum_server::tls_rustls::RustlsConfig;
 use chrono::Duration as ChronoDuration;
 use lab_resource_manager::{
     application::usecases::{
+        accept_reservation_proposal::AcceptReservationProposalUseCase,
         create_resource_usage::CreateResourceUsageUseCase,
         delete_resource_usage::DeleteResourceUsageUseCase,
         get_resource_usage_by_id::GetResourceUsageByIdUseCase,
@@ -117,6 +118,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ));
 
     let create_usecase = Arc::new(CreateResourceUsageUseCase::new(resource_usage_repo.clone()));
+    let accept_proposal_usecase = Arc::new(AcceptReservationProposalUseCase::new(
+        resource_usage_repo.clone(),
+    ));
     let update_usecase = Arc::new(UpdateResourceUsageUseCase::new(resource_usage_repo.clone()));
     let delete_usecase = Arc::new(DeleteResourceUsageUseCase::new(resource_usage_repo.clone()));
     let list_all_usecase = Arc::new(ListAllFutureResourceUsagesUseCase::new(
@@ -230,6 +234,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         mcp_token_repo.clone(),
         grant_access_usecase,
         create_usecase,
+        accept_proposal_usecase,
         update_usecase,
         delete_usecase,
         notify_usecase,

--- a/src/domain/ports/reservation_proposal.rs
+++ b/src/domain/ports/reservation_proposal.rs
@@ -9,9 +9,11 @@ use chrono::{DateTime, Duration, Utc};
 ///
 /// 予約チャンネルへのブロードキャスト通知（`Notifier`）とは異なり、
 /// 特定の利用者本人への直接的なやり取り（Slack DM等）を前提とするため別ポートとする。
+/// ひとりの利用者が同じ機会に使い始めたリソースは、まとめて1件の提案として提示する。
+/// リソースごとに提案を分けると、利用者は枚数分のボタンを押すことになる。
 #[derive(Debug, Clone)]
 pub struct ReservationProposal {
-    resource: Resource,
+    resources: Vec<Resource>,
     owner_email: EmailAddress,
     external_identity: ExternalIdentity,
     active_since: DateTime<Utc>,
@@ -21,14 +23,14 @@ pub struct ReservationProposal {
 impl ReservationProposal {
     /// 新しい提案を作成
     pub fn new(
-        resource: Resource,
+        resources: Vec<Resource>,
         owner_email: EmailAddress,
         external_identity: ExternalIdentity,
         active_since: DateTime<Utc>,
         duration_candidates: Vec<Duration>,
     ) -> Self {
         Self {
-            resource,
+            resources,
             owner_email,
             external_identity,
             active_since,
@@ -37,8 +39,8 @@ impl ReservationProposal {
     }
 
     /// 対象リソースを取得
-    pub fn resource(&self) -> &Resource {
-        &self.resource
+    pub fn resources(&self) -> &[Resource] {
+        &self.resources
     }
 
     /// 提案先のメールアドレスを取得

--- a/src/infrastructure/repositories/resource_usage/google_calendar/repository.rs
+++ b/src/infrastructure/repositories/resource_usage/google_calendar/repository.rs
@@ -17,7 +17,8 @@ use google_calendar3::{
     hyper_util::{client::legacy::Client, rt::TokioExecutor},
     yup_oauth2,
 };
-use std::sync::Arc;
+use std::collections::HashSet;
+use std::sync::{Arc, Mutex};
 
 /// アプリ経由で作成されたイベントのdescriptionに付与される、予約者メールアドレス行の接頭辞
 const OWNER_LINE_PREFIX: &str = "予約者: ";
@@ -47,6 +48,10 @@ pub struct GoogleCalendarUsageRepository {
     config: ResourceConfig,
     service_account_email: String,
     id_mapper: Arc<IdMapper>,
+    /// 解釈失敗を既に警告したイベントID
+    ///
+    /// 同じイベントは取得のたびに失敗するため、警告を出し続けるとログが埋まる。
+    reported_parse_failures: Mutex<HashSet<String>>,
 }
 
 impl GoogleCalendarUsageRepository {
@@ -85,6 +90,7 @@ impl GoogleCalendarUsageRepository {
             config,
             service_account_email,
             id_mapper: Arc::new(id_mapper),
+            reported_parse_failures: Mutex::new(HashSet::new()),
         })
     }
 
@@ -101,6 +107,7 @@ impl GoogleCalendarUsageRepository {
             config,
             service_account_email,
             id_mapper: Arc::new(IdMapper::new(id_mappings_path)?),
+            reported_parse_failures: Mutex::new(HashSet::new()),
         })
     }
 
@@ -150,6 +157,14 @@ impl GoogleCalendarUsageRepository {
         Ok(all_events)
     }
 
+    /// 解釈失敗を警告として報告すべきか（イベントごとに初回のみ）
+    pub(super) fn should_report_parse_failure(&self, event_id: &str) -> bool {
+        self.reported_parse_failures
+            .lock()
+            .expect("解釈失敗の記録ロックを取得できませんでした")
+            .insert(event_id.to_string())
+    }
+
     /// 取得したイベント群をResourceUsageへ変換する
     ///
     /// 予約として解釈できないイベント（カレンダー上で直接作られた自由記述のイベントなど）は
@@ -162,12 +177,19 @@ impl GoogleCalendarUsageRepository {
                 match self.parse_event(event, &calendar_id, &resource_context) {
                     Ok(usage) => Some(usage),
                     Err(e) => {
-                        tracing::warn!(
-                            "イベントを予約として解釈できませんでした: calendar_id={}, event_id={}, error={}",
-                            calendar_id,
-                            event_id,
-                            e
-                        );
+                        if self.should_report_parse_failure(&event_id) {
+                            tracing::warn!(
+                                "イベントを予約として解釈できませんでした: calendar_id={}, event_id={}, error={}",
+                                calendar_id,
+                                event_id,
+                                e
+                            );
+                        } else {
+                            tracing::debug!(
+                                "イベントを予約として解釈できませんでした(既報): event_id={}",
+                                event_id
+                            );
+                        }
                         None
                     }
                 }

--- a/src/infrastructure/repositories/resource_usage/google_calendar/repository_tests.rs
+++ b/src/infrastructure/repositories/resource_usage/google_calendar/repository_tests.rs
@@ -358,3 +358,22 @@ async fn find_future_keeps_ongoing_reservation() {
         "開始時刻が過去でも進行中の予約は含めるべき"
     );
 }
+
+#[tokio::test]
+async fn parse_failures_are_reported_once_per_event() {
+    let (repository, _gateway, _mapping_path) = repository_with(vec![]);
+
+    // 同じイベントの解釈失敗を毎回警告すると、ポーリングのたびにログが積み上がる
+    assert!(
+        repository.should_report_parse_failure("event-a"),
+        "初回は報告する"
+    );
+    assert!(
+        !repository.should_report_parse_failure("event-a"),
+        "2回目以降は報告しない"
+    );
+    assert!(
+        repository.should_report_parse_failure("event-b"),
+        "別のイベントは報告する"
+    );
+}

--- a/src/infrastructure/repositories/resource_usage/mock.rs
+++ b/src/infrastructure/repositories/resource_usage/mock.rs
@@ -38,8 +38,14 @@ impl ResourceUsageRepository for MockUsageRepository {
     }
 
     async fn find_future(&self) -> Result<Vec<ResourceUsage>, RepositoryError> {
+        // ポートの契約どおり、終了済みのリソース使用は返さない
+        let now = chrono::Utc::now();
         let storage = self.storage.lock().unwrap();
-        Ok(storage.values().cloned().collect())
+        Ok(storage
+            .values()
+            .filter(|usage| usage.time_period().end() > now)
+            .cloned()
+            .collect())
     }
 
     async fn find_overlapping(

--- a/src/infrastructure/reservation_proposal/mock.rs
+++ b/src/infrastructure/reservation_proposal/mock.rs
@@ -31,7 +31,12 @@ impl ReservationProposalNotifier for MockReservationProposalNotifier {
         println!(
             "📤 [MockReservationProposalNotifier] {} へ {} の予約を提案 (候補: {}件)",
             proposal.owner_email().as_str(),
-            proposal.resource(),
+            proposal
+                .resources()
+                .iter()
+                .map(|resource| resource.to_string())
+                .collect::<Vec<_>>()
+                .join(", "),
             proposal.duration_candidates().len()
         );
         self.proposals.lock().unwrap().push(proposal);

--- a/src/infrastructure/reservation_proposal/slack.rs
+++ b/src/infrastructure/reservation_proposal/slack.rs
@@ -1,7 +1,7 @@
 //! Slack DM経由の事後予約提案実装
 
 use crate::domain::aggregates::identity_link::value_objects::ExternalSystem;
-use crate::domain::aggregates::resource_usage::value_objects::Resource;
+use crate::domain::aggregates::resource_usage::value_objects::{Gpu, Resource};
 use crate::domain::ports::notifier::NotificationError;
 use crate::domain::ports::repositories::IdentityLinkRepository;
 use crate::domain::ports::reservation_proposal::{
@@ -20,14 +20,14 @@ use crate::interface::slack::constants::ACTION_ACCEPT_RESERVATION_PROPOSAL;
 ///
 /// `Resource`/`TimePeriod`はドメイン層でserde非依存を保っているため、
 /// Slackボタンの`value`にエンコードするための専用DTOとして定義する。
+/// Slackボタンの`value`は文字数上限があるため、モデル名のような復元可能な情報は持たせない。
+/// モデル名は受諾時にリソース設定から引き直す。
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ProposalAcceptPayload {
     /// サーバー名
     pub server: String,
-    /// GPUデバイス番号
-    pub device_number: u32,
-    /// GPUモデル名
-    pub model: String,
+    /// GPUデバイス番号（同じ機会に使い始めた分をまとめて持つ）
+    pub device_numbers: Vec<u32>,
     /// 提案先のメールアドレス
     pub owner_email: String,
     /// 利用開始時刻（予約の開始時刻としてそのまま使う）
@@ -92,11 +92,7 @@ impl SlackReservationProposalNotifier {
 #[async_trait]
 impl ReservationProposalNotifier for SlackReservationProposalNotifier {
     async fn propose(&self, proposal: ReservationProposal) -> Result<(), NotificationError> {
-        let Resource::Gpu(gpu) = proposal.resource() else {
-            return Err(NotificationError::SendFailure(
-                "GPU以外のリソースの事後予約提案はサポートしていません".to_string(),
-            ));
-        };
+        let gpus = collect_gpus(&proposal)?;
 
         let slack_user_id = self.resolve_slack_user_id(&proposal).await?;
 
@@ -113,9 +109,9 @@ impl ReservationProposalNotifier for SlackReservationProposalNotifier {
 
         let text = format!(
             "{} が予約なしで使用中です。事後予約を作成しますか？",
-            proposal.resource()
+            format_resource_list(&proposal)
         );
-        let blocks = build_proposal_blocks(&proposal, gpu, &text);
+        let blocks = build_proposal_blocks(&proposal, &gpus, &text);
 
         let post_req = SlackApiChatPostMessageRequest::new(
             open_resp.channel.id,
@@ -133,20 +129,60 @@ impl ReservationProposalNotifier for SlackReservationProposalNotifier {
     }
 }
 
+/// 提案対象のGPUを取り出す
+///
+/// 事後予約はGPUの実利用検知から生まれるため、対象は必ずGPUであり、
+/// 同一サーバーに属している（同じサーバーの観測結果をまとめたもの）。
+fn collect_gpus(proposal: &ReservationProposal) -> Result<Vec<Gpu>, NotificationError> {
+    let mut gpus = Vec::with_capacity(proposal.resources().len());
+
+    for resource in proposal.resources() {
+        let Resource::Gpu(gpu) = resource else {
+            return Err(NotificationError::SendFailure(
+                "GPU以外のリソースの事後予約提案はサポートしていません".to_string(),
+            ));
+        };
+        gpus.push(gpu.clone());
+    }
+
+    if gpus.is_empty() {
+        return Err(NotificationError::SendFailure(
+            "提案対象のリソースがありません".to_string(),
+        ));
+    }
+
+    Ok(gpus)
+}
+
+/// 提案対象のリソースを読みやすく並べる
+fn format_resource_list(proposal: &ReservationProposal) -> String {
+    proposal
+        .resources()
+        .iter()
+        .map(|resource| resource.to_string())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
 /// 事後予約提案のBlock Kitメッセージを構築する（純粋関数、ユニットテスト対象）
 fn build_proposal_blocks(
     proposal: &ReservationProposal,
-    gpu: &crate::domain::aggregates::resource_usage::value_objects::Gpu,
+    gpus: &[Gpu],
     text: &str,
 ) -> Vec<SlackBlock> {
+    let server = gpus
+        .first()
+        .map(|gpu| gpu.server().to_string())
+        .unwrap_or_default();
+    let device_numbers: Vec<u32> = gpus.iter().map(|gpu| gpu.device_number()).collect();
+
     let buttons: Vec<serde_json::Value> = proposal
         .duration_candidates()
         .iter()
         .map(|duration| {
             let payload = ProposalAcceptPayload {
-                server: gpu.server().to_string(),
-                device_number: gpu.device_number(),
-                model: gpu.model().to_string(),
+                server: server.clone(),
+                device_numbers: device_numbers.clone(),
                 owner_email: proposal.owner_email().as_str().to_string(),
                 active_since: proposal.active_since(),
                 duration_minutes: duration.num_minutes(),
@@ -212,8 +248,24 @@ mod tests {
     use chrono::Utc;
 
     fn sample_proposal(duration_candidates: Vec<Duration>) -> ReservationProposal {
+        sample_proposal_with_devices(vec![0], duration_candidates)
+    }
+
+    fn sample_proposal_with_devices(
+        device_numbers: Vec<u32>,
+        duration_candidates: Vec<Duration>,
+    ) -> ReservationProposal {
         ReservationProposal::new(
-            Resource::Gpu(Gpu::new("Thalys".to_string(), 0, "A100".to_string())),
+            device_numbers
+                .into_iter()
+                .map(|device_number| {
+                    Resource::Gpu(Gpu::new(
+                        "Thalys".to_string(),
+                        device_number,
+                        "A100".to_string(),
+                    ))
+                })
+                .collect(),
             EmailAddress::new("user@example.com".to_string()).unwrap(),
             ExternalIdentity::new(
                 ExternalSystem::Os {
@@ -246,11 +298,9 @@ mod tests {
     fn test_build_proposal_blocks_button_count_matches_candidates() {
         let candidates = vec![Duration::hours(1), Duration::hours(2), Duration::hours(3)];
         let proposal = sample_proposal(candidates.clone());
-        let Resource::Gpu(gpu) = proposal.resource() else {
-            unreachable!()
-        };
+        let gpus = collect_gpus(&proposal).unwrap();
 
-        let blocks = build_proposal_blocks(&proposal, gpu, "test message");
+        let blocks = build_proposal_blocks(&proposal, &gpus, "test message");
         assert_eq!(blocks.len(), 2);
 
         let json = serde_json::to_value(&blocks).unwrap();
@@ -262,11 +312,9 @@ mod tests {
     fn test_build_proposal_blocks_action_ids_are_unique_within_block() {
         let candidates = vec![Duration::hours(1), Duration::hours(2), Duration::hours(3)];
         let proposal = sample_proposal(candidates.clone());
-        let Resource::Gpu(gpu) = proposal.resource() else {
-            unreachable!()
-        };
+        let gpus = collect_gpus(&proposal).unwrap();
 
-        let blocks = build_proposal_blocks(&proposal, gpu, "test message");
+        let blocks = build_proposal_blocks(&proposal, &gpus, "test message");
         let json = serde_json::to_value(&blocks).unwrap();
         let action_ids: Vec<String> = json[1]["elements"]
             .as_array()
@@ -289,8 +337,7 @@ mod tests {
     fn test_proposal_accept_payload_round_trip() {
         let payload = ProposalAcceptPayload {
             server: "Thalys".to_string(),
-            device_number: 0,
-            model: "A100".to_string(),
+            device_numbers: vec![0, 1, 4],
             owner_email: "user@example.com".to_string(),
             active_since: Utc::now(),
             duration_minutes: 120,

--- a/src/interface/slack/app.rs
+++ b/src/interface/slack/app.rs
@@ -2,6 +2,7 @@
 //!
 //! 依存関係を管理し、Slackインタラクションのメインエントリポイントを提供
 
+use crate::application::usecases::accept_reservation_proposal::AcceptReservationProposalUseCase;
 use crate::application::usecases::create_resource_usage::CreateResourceUsageUseCase;
 use crate::application::usecases::delete_resource_usage::DeleteResourceUsageUseCase;
 use crate::application::usecases::grant_user_resource_access::GrantUserResourceAccessUseCase;
@@ -34,6 +35,7 @@ where
     // UseCases
     grant_access_usecase: Arc<GrantUserResourceAccessUseCase>,
     create_resource_usage_usecase: Arc<CreateResourceUsageUseCase<R>>,
+    accept_reservation_proposal_usecase: Arc<AcceptReservationProposalUseCase<R>>,
     update_resource_usage_usecase: Arc<UpdateResourceUsageUseCase<R>>,
     delete_usage_usecase: Arc<DeleteResourceUsageUseCase<R>>,
     notify_usecase: Arc<NotifyFutureResourceUsageChangesUseCase<R, N>>,
@@ -69,6 +71,7 @@ where
         mcp_token_repo: Arc<dyn McpTokenRepository>,
         grant_access_usecase: Arc<GrantUserResourceAccessUseCase>,
         create_resource_usage_usecase: Arc<CreateResourceUsageUseCase<R>>,
+        accept_reservation_proposal_usecase: Arc<AcceptReservationProposalUseCase<R>>,
         update_resource_usage_usecase: Arc<UpdateResourceUsageUseCase<R>>,
         delete_usage_usecase: Arc<DeleteResourceUsageUseCase<R>>,
         notify_usecase: Arc<NotifyFutureResourceUsageChangesUseCase<R, N>>,
@@ -82,6 +85,7 @@ where
             mcp_token_repo,
             grant_access_usecase,
             create_resource_usage_usecase,
+            accept_reservation_proposal_usecase,
             update_resource_usage_usecase,
             delete_usage_usecase,
             notify_usecase,
@@ -334,6 +338,10 @@ where
 
     pub fn create_resource_usage_usecase(&self) -> &Arc<CreateResourceUsageUseCase<R>> {
         &self.create_resource_usage_usecase
+    }
+
+    pub fn accept_reservation_proposal_usecase(&self) -> &Arc<AcceptReservationProposalUseCase<R>> {
+        &self.accept_reservation_proposal_usecase
     }
 
     pub fn update_resource_usage_usecase(&self) -> &Arc<UpdateResourceUsageUseCase<R>> {

--- a/src/interface/slack/block_actions/accept_proposal_button.rs
+++ b/src/interface/slack/block_actions/accept_proposal_button.rs
@@ -1,6 +1,6 @@
 //! 事後予約提案の受諾ボタンハンドラ
 
-use crate::domain::aggregates::resource_usage::value_objects::{Gpu, Resource, TimePeriod};
+use crate::domain::aggregates::resource_usage::value_objects::{Gpu, Resource};
 use crate::domain::common::EmailAddress;
 use crate::domain::ports::notifier::Notifier;
 use crate::domain::ports::repositories::ResourceUsageRepository;
@@ -71,28 +71,58 @@ where
     let payload: ProposalAcceptPayload = serde_json::from_str(value)?;
 
     info!(
-        "📍 事後予約作成: server={}, device={}, owner={}",
-        payload.server, payload.device_number, payload.owner_email
+        "📍 事後予約作成: server={}, devices={:?}, owner={}, duration_minutes={}",
+        payload.server, payload.device_numbers, payload.owner_email, payload.duration_minutes
     );
 
-    let resource = Resource::Gpu(Gpu::new(
-        payload.server,
-        payload.device_number,
-        payload.model,
-    ));
+    let resources = resolve_gpu_resources(app, &payload.server, &payload.device_numbers)?;
     let owner_email = EmailAddress::new(payload.owner_email)?;
-    let start = payload.active_since;
-    let end = start + Duration::minutes(payload.duration_minutes);
-    let time_period = TimePeriod::new(start, end)?;
 
-    app.create_resource_usage_usecase()
+    app.accept_reservation_proposal_usecase()
         .execute(
             owner_email,
-            time_period,
-            vec![resource],
-            Some("GPU実利用検知による事後予約".to_string()),
+            resources,
+            payload.active_since,
+            Duration::minutes(payload.duration_minutes),
         )
         .await?;
 
     Ok(())
+}
+
+/// デバイス番号からGPUリソースを復元する
+///
+/// モデル名はボタンのペイロードに載せていないため、リソース設定から引く。
+fn resolve_gpu_resources<R, N>(
+    app: &SlackApp<R, N>,
+    server_name: &str,
+    device_numbers: &[u32],
+) -> Result<Vec<Resource>, Box<dyn std::error::Error + Send + Sync>>
+where
+    R: ResourceUsageRepository + Send + Sync + 'static,
+    N: Notifier + Send + Sync + 'static,
+{
+    let server = app
+        .resource_config()
+        .get_server(server_name)
+        .ok_or_else(|| format!("サーバーが見つかりません: {}", server_name))?;
+
+    device_numbers
+        .iter()
+        .map(|device_number| {
+            let device = server
+                .devices
+                .iter()
+                .find(|device| device.id == *device_number)
+                .ok_or_else(|| {
+                    format!("デバイス{}が{}に存在しません", device_number, server_name)
+                })?;
+
+            Ok(Resource::Gpu(Gpu::new(
+                server_name.to_string(),
+                *device_number,
+                device.model.clone(),
+            )))
+        })
+        .collect()
 }


### PR DESCRIPTION
## Why

The LRM host runs with `UNRESERVED_USAGE_THRESHOLD_SECS=0` and six duration candidates (1,2,3,6,12,24h), so a proposal DM arrives the moment a GPU is touched, carrying six buttons. One DM was sent **per resource**, so a user who started three GPUs received three DMs and pressed three buttons.

Service logs show exactly that:

```
7/25 10:24:43  Freccia device=4  soruton
7/25 10:24:44  Freccia device=5  soruton
7/25 10:24:45  Freccia device=6  soruton
```

Three presses, one second apart. Those are distinct resources, so they are not duplicates — but the same clusters reappear hours later for the same devices:

```
Thalys  device=1  kawakin:  14:16:21 → 17:40:06 → 17:48:42
Thalys  device=4  kawakin:  14:16:23 → 17:40:04
Thalys  device=0  mk079:    13:24:29 → 17:57:12
Freccia device=1  kawakin:  10:56:39 → 15:03:52 → 17:48:41
```

The counts match the duplicate events one-for-one. There were no service restarts on 7/25, so `proposed_keys` was intact and nothing was re-proposed — these are re-presses of the same DM, which stays pressable indefinitely. Some re-presses used the same duration (accidental), others a longer one (intent to extend). Either way a separate reservation was created.

Two problems, one cause: acceptance meant "create a reservation" rather than "settle this occasion".

## What

- `ReservationProposal` holds `Vec<Resource>`. Observations from the same user whose start times fall within 5 minutes form a single proposal, using the earliest `active_since`. One DM, one press, one reservation covering every GPU.
- New `AcceptReservationProposalUseCase`. Accepting means "make this occasion's reservation this long": if a reservation with the same owner, start time and resource set exists, its period is updated; otherwise one is created. Extending and shrinking both work, and a second press cannot add a reservation.
- This depends on the previous PR in the stack. By the time a user presses again, the existing reservation has often already ended, so it is only findable because `find_overlapping` no longer filters ended reservations out.
- `ProposalAcceptPayload` now carries `device_numbers: Vec<u32>`; the model name is resolved from `resources.toml` at acceptance time, since Slack button `value` has a length limit.
- Proposal delivery is logged. There was no record of it at all, so it was impossible to tell from logs whether a proposal had been sent, re-sent, or never sent.

## Notes

`ExternalIdentity` includes `linked_at: Utc::now()` in its derived `Eq`/`Hash`, so two values describing the same user never compare equal. Grouping therefore keys on `(ExternalSystem, user_id)`. Worth knowing: any code using `ExternalIdentity` as a `HashMap`/`HashSet` key hits the same trap, and it fails silently rather than loudly.

Tests for `reconcile_observed_usages` moved to their own file — the module had grown past 900 lines.

## Test plan

- [x] 6 tests for the accept use case (update on second acceptance, update even when the existing reservation has ended, shrink on a shorter choice, create when nothing matches, reject on another user's overlap, different resource set is a separate occasion)
- [x] 4 tests for grouping (several GPUs become one proposal with the earliest start, distant observations stay separate, reserved resources excluded, one proposal per occasion)
- [x] All 10 confirmed failing before implementation
- [x] `cargo test` — 110 passed
- [x] `cargo clippy --all-targets` — no warnings
- [x] `cargo fmt --check`
- [ ] Not exercised against a real Slack workspace. Needs a run in the lab environment before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KHaZgaoJcQjDGXZF9PJ9S
