### PR TITLE
feat: show the reserver's OS user name and reservation id on the calendar

### DIFF
--- a/src/bin/lab-resource-manager.rs
+++ b/src/bin/lab-resource-manager.rs
@@ -99,6 +99,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             service_account_key,
             resource_config.as_ref().clone(),
             app_config.calendar_mappings_file.clone(),
+            identity_repo.clone(),
         )
         .await?,
     );

--- a/src/infrastructure/repositories/resource_usage/google_calendar/repository.rs
+++ b/src/infrastructure/repositories/resource_usage/google_calendar/repository.rs
@@ -1,12 +1,15 @@
 use super::event_gateway::{CalendarEventGateway, GoogleCalendarEventGateway};
 use super::id_mapper::{ExternalId, IdMapper};
+use crate::domain::aggregates::identity_link::value_objects::ExternalSystem;
 use crate::domain::aggregates::resource_usage::{
     entity::ResourceUsage,
     factory::ResourceFactory,
     value_objects::{Resource, TimePeriod, UsageId},
 };
 use crate::domain::common::EmailAddress;
-use crate::domain::ports::repositories::{RepositoryError, ResourceUsageRepository};
+use crate::domain::ports::repositories::{
+    IdentityLinkRepository, RepositoryError, ResourceUsageRepository,
+};
 use crate::infrastructure::config::ResourceConfig;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -31,6 +34,12 @@ const MANAGED_SECTION_BEGIN: &str = "[lab-resource-manager:managed-section:begin
 /// アプリが管理するセクションの終了マーカー。このマーカーより後ろが備考として扱われる。
 const MANAGED_SECTION_END: &str = "[lab-resource-manager:managed-section:end]";
 
+/// 予約者のOSユーザー名行の接頭辞
+const OS_USER_LINE_PREFIX: &str = "OS: ";
+
+/// 予約IDの行の接頭辞
+const RESERVATION_ID_LINE_PREFIX: &str = "予約ID: ";
+
 /// キャンセル済みイベントのstatus値
 const EVENT_STATUS_CANCELLED: &str = "cancelled";
 
@@ -48,6 +57,8 @@ pub struct GoogleCalendarUsageRepository {
     config: ResourceConfig,
     service_account_email: String,
     id_mapper: Arc<IdMapper>,
+    /// 予約者の付加情報（OSユーザー名など）を引くためのリポジトリ
+    identity_repo: Arc<dyn IdentityLinkRepository>,
     /// 解釈失敗を既に警告したイベントID
     ///
     /// 同じイベントは取得のたびに失敗するため、警告を出し続けるとログが埋まる。
@@ -65,6 +76,7 @@ impl GoogleCalendarUsageRepository {
         service_account_key: &str,
         config: ResourceConfig,
         id_mappings_path: std::path::PathBuf,
+        identity_repo: Arc<dyn IdentityLinkRepository>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let secret = yup_oauth2::read_service_account_key(service_account_key).await?;
         let service_account_email = secret.client_email.clone();
@@ -90,6 +102,7 @@ impl GoogleCalendarUsageRepository {
             config,
             service_account_email,
             id_mapper: Arc::new(id_mapper),
+            identity_repo,
             reported_parse_failures: Mutex::new(HashSet::new()),
         })
     }
@@ -101,14 +114,78 @@ impl GoogleCalendarUsageRepository {
         config: ResourceConfig,
         service_account_email: String,
         id_mappings_path: std::path::PathBuf,
+        identity_repo: Arc<dyn IdentityLinkRepository>,
     ) -> Result<Self, RepositoryError> {
         Ok(Self {
             gateway,
             config,
             service_account_email,
             id_mapper: Arc::new(IdMapper::new(id_mappings_path)?),
+            identity_repo,
             reported_parse_failures: Mutex::new(HashSet::new()),
         })
+    }
+
+    /// イベントのdescriptionを組み立てる
+    ///
+    /// アプリが管理する行はマーカーで囲む。カレンダーを開いた人が状況を把握できるよう、
+    /// 予約者のメールアドレスに加えて、分かる範囲の情報（OSユーザー名・予約ID）を並べる。
+    /// 備考はマーカーの外に置き、利用者が自由に編集できる領域として残す。
+    pub(super) async fn build_description(&self, usage: &ResourceUsage) -> String {
+        let mut lines = vec![
+            MANAGED_SECTION_BEGIN.to_string(),
+            format!("{OWNER_LINE_PREFIX}{}", usage.owner_email().as_str()),
+        ];
+
+        if let Some(os_user) = self.resolve_os_user_name(usage).await {
+            lines.push(format!("{OS_USER_LINE_PREFIX}{os_user}"));
+        }
+
+        lines.push(format!(
+            "{RESERVATION_ID_LINE_PREFIX}{}",
+            usage.id().as_str()
+        ));
+        lines.push(MANAGED_SECTION_END.to_string());
+
+        let mut description = lines.join("\n");
+
+        if let Some(notes) = usage.notes() {
+            description.push_str(&format!("\n\n{notes}"));
+        }
+
+        description
+    }
+
+    /// 予約対象サーバーにおける予約者のOSユーザー名を引く
+    ///
+    /// OSユーザー名の名前空間はサーバーごとに異なりうるため、予約したサーバーの紐付けを見る。
+    /// 部屋の予約や紐付けが無い場合はNoneを返す。表示のための情報であり、
+    /// 引けないことを理由に予約の保存を失敗させない。
+    async fn resolve_os_user_name(&self, usage: &ResourceUsage) -> Option<String> {
+        let server = usage
+            .resources()
+            .iter()
+            .find_map(|resource| match resource {
+                Resource::Gpu(gpu) => Some(gpu.server().to_string()),
+                Resource::Room { .. } => None,
+            })?;
+
+        let identity_link = self
+            .identity_repo
+            .find_by_email(usage.owner_email())
+            .await
+            .inspect_err(|e| {
+                tracing::warn!(
+                    "予約者の紐付け取得に失敗しました（OS名は省略します）: {}",
+                    e
+                )
+            })
+            .ok()
+            .flatten()?;
+
+        identity_link
+            .get_identity_for_system(&ExternalSystem::Os { server })
+            .map(|identity| identity.user_id().to_string())
     }
 
     /// 管理対象のカレンダー一覧
@@ -277,48 +354,57 @@ impl GoogleCalendarUsageRepository {
         let title = event.summary.as_ref().unwrap_or(&default_title);
         let items = self.parse_resources(title, resource_context)?;
 
-        // アプリ管理セクション（開始〜終了マーカー）の外側を備考として抽出する。
-        // ユーザーが開始マーカーより前にメモを追記した場合も失わないよう、
-        // マーカーの前後両方を拾って結合する。
-        // 旧形式（"予約者: xxx"の1行目のみでマーカー無し）は先頭行のみ除外し、
-        // Googleカレンダー上で直接作成されたイベント（マーカーも予約者行も無し）は
-        // description全体をそのまま備考として扱う
-        let notes = event.description.as_ref().and_then(|desc| {
-            let body: String =
-                if let Some((before_begin, after_begin)) = desc.split_once(MANAGED_SECTION_BEGIN) {
-                    match after_begin.split_once(MANAGED_SECTION_END) {
-                        Some((_, after_end)) => {
-                            let before = before_begin.trim();
-                            let after = after_end.trim();
-                            if before.is_empty() {
-                                after.to_string()
-                            } else if after.is_empty() {
-                                before.to_string()
-                            } else {
-                                format!("{before}\n\n{after}")
-                            }
-                        }
-                        // 開始マーカーのみで終了マーカーが無い想定外の編集は、
-                        // 安全側に倒してdescription全体を備考として扱う
-                        None => desc.clone(),
-                    }
-                } else if desc.starts_with(OWNER_LINE_PREFIX) {
-                    desc.split_once('\n')
-                        .map(|(_, rest)| rest.to_string())
-                        .unwrap_or_default()
-                } else {
-                    desc.clone()
-                };
-            let body = body.trim();
-            if body.is_empty() {
-                None
-            } else {
-                Some(body.to_string())
-            }
-        });
+        let notes = event
+            .description
+            .as_ref()
+            .and_then(|desc| Self::extract_notes(desc));
 
         ResourceUsage::reconstruct(id, user, time_period, items, notes)
             .map_err(RepositoryError::from)
+    }
+
+    /// descriptionから備考（アプリ管理セクションの外側）を取り出す
+    ///
+    /// ユーザーが開始マーカーより前にメモを追記した場合も失わないよう、
+    /// マーカーの前後両方を拾って結合する。
+    /// 旧形式（"予約者: xxx"の1行目のみでマーカー無し）は先頭行のみ除外し、
+    /// Googleカレンダー上で直接作成されたイベント（マーカーも予約者行も無し）は
+    /// description全体をそのまま備考として扱う。
+    pub(super) fn extract_notes(description: &str) -> Option<String> {
+        let body: String = if let Some((before_begin, after_begin)) =
+            description.split_once(MANAGED_SECTION_BEGIN)
+        {
+            match after_begin.split_once(MANAGED_SECTION_END) {
+                Some((_, after_end)) => {
+                    let before = before_begin.trim();
+                    let after = after_end.trim();
+                    if before.is_empty() {
+                        after.to_string()
+                    } else if after.is_empty() {
+                        before.to_string()
+                    } else {
+                        format!("{before}\n\n{after}")
+                    }
+                }
+                // 開始マーカーのみで終了マーカーが無い想定外の編集は、
+                // 安全側に倒してdescription全体を備考として扱う
+                None => description.to_string(),
+            }
+        } else if description.starts_with(OWNER_LINE_PREFIX) {
+            description
+                .split_once('\n')
+                .map(|(_, rest)| rest.to_string())
+                .unwrap_or_default()
+        } else {
+            description.to_string()
+        };
+
+        let body = body.trim();
+        if body.is_empty() {
+            None
+        } else {
+            Some(body.to_string())
+        }
     }
 
     /// メールアドレスからEmailAddressを作成
@@ -450,7 +536,10 @@ impl GoogleCalendarUsageRepository {
     /// # 前提条件
     /// このメソッドは、get_calendar_id_for_usageで検証済みのResourceUsageを受け取ることを前提としています。
     /// すなわち、すべてのリソースが同一のカレンダーに属していることが保証されています。
-    fn create_event_from_usage(&self, usage: &ResourceUsage) -> Result<Event, RepositoryError> {
+    async fn create_event_from_usage(
+        &self,
+        usage: &ResourceUsage,
+    ) -> Result<Event, RepositoryError> {
         // 注: get_calendar_id_for_usageで検証済みのため、resources()[0]は安全に使用できる
         let summary = match &usage.resources()[0] {
             Resource::Gpu(_) => self.format_gpu_spec(usage.resources()).ok_or_else(|| {
@@ -459,18 +548,7 @@ impl GoogleCalendarUsageRepository {
             Resource::Room { name } => name.clone(),
         };
 
-        // descriptionに予約者情報と備考を含める。予約者情報はアプリが管理するセクションとして
-        // 開始・終了マーカーで囲み、ユーザーが誤って編集しないよう明示する
-        let description = {
-            let mut desc = format!(
-                "{MANAGED_SECTION_BEGIN}\n{OWNER_LINE_PREFIX}{}\n{MANAGED_SECTION_END}",
-                usage.owner_email().as_str()
-            );
-            if let Some(notes) = usage.notes() {
-                desc.push_str(&format!("\n\n{}", notes));
-            }
-            desc
-        };
+        let description = self.build_description(usage).await;
 
         Ok(Event {
             summary: Some(summary),
@@ -694,7 +772,7 @@ impl ResourceUsageRepository for GoogleCalendarUsageRepository {
             if external_id.calendar_id == new_calendar_id {
                 // 同じカレンダー → 更新
                 // IMPORTANT: update API用に id フィールドを含む Event を作成
-                let mut event = self.create_event_from_usage(usage)?;
+                let mut event = self.create_event_from_usage(usage).await?;
                 event.id = Some(external_id.event_id.clone());
 
                 self.gateway
@@ -711,7 +789,7 @@ impl ResourceUsageRepository for GoogleCalendarUsageRepository {
                     })?;
 
                 // 新しいカレンダーにイベントを作成
-                let event = self.create_event_from_usage(usage)?;
+                let event = self.create_event_from_usage(usage).await?;
                 let created_event = self
                     .gateway
                     .insert_event(&new_calendar_id, event)
@@ -738,7 +816,7 @@ impl ResourceUsageRepository for GoogleCalendarUsageRepository {
             }
         } else {
             // 新規 → 作成
-            let event = self.create_event_from_usage(usage)?;
+            let event = self.create_event_from_usage(usage).await?;
             let created_event = self.gateway.insert_event(&new_calendar_id, event).await?;
 
             // Event IDを取得してマッピングを保存

--- a/src/infrastructure/repositories/resource_usage/google_calendar/repository_tests.rs
+++ b/src/infrastructure/repositories/resource_usage/google_calendar/repository_tests.rs
@@ -5,8 +5,13 @@
 
 use super::event_gateway::CalendarEventGateway;
 use super::repository::GoogleCalendarUsageRepository;
-use crate::domain::aggregates::resource_usage::value_objects::TimePeriod;
-use crate::domain::ports::repositories::{RepositoryError, ResourceUsageRepository};
+use crate::domain::aggregates::identity_link::entity::IdentityLink;
+use crate::domain::aggregates::identity_link::value_objects::{ExternalIdentity, ExternalSystem};
+use crate::domain::aggregates::resource_usage::entity::ResourceUsage;
+use crate::domain::aggregates::resource_usage::value_objects::{Resource, TimePeriod};
+use crate::domain::ports::repositories::{
+    IdentityLinkRepository, RepositoryError, ResourceUsageRepository,
+};
 use crate::infrastructure::config::{DeviceConfig, ResourceConfig, ServerConfig};
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
@@ -207,6 +212,7 @@ fn repository_with(
         test_config(),
         SERVICE_ACCOUNT_EMAIL.to_string(),
         mapping_path.path(),
+        Arc::new(StubIdentityLinkRepository::default()),
     )
     .expect("テスト用リポジトリの構築に失敗");
 
@@ -375,5 +381,318 @@ async fn parse_failures_are_reported_once_per_event() {
     assert!(
         repository.should_report_parse_failure("event-b"),
         "別のイベントは報告する"
+    );
+}
+
+/// メールアドレスからOSユーザー名を引けるテスト用のIdentityLinkリポジトリ
+#[derive(Default)]
+struct StubIdentityLinkRepository {
+    /// (email, server) -> OSユーザー名
+    os_users: Vec<(String, String, String)>,
+}
+
+impl StubIdentityLinkRepository {
+    fn with_os_user(mut self, email: &str, server: &str, os_user: &str) -> Self {
+        self.os_users
+            .push((email.to_string(), server.to_string(), os_user.to_string()));
+        self
+    }
+}
+
+#[async_trait]
+impl IdentityLinkRepository for StubIdentityLinkRepository {
+    async fn find_by_email(
+        &self,
+        email: &crate::domain::common::EmailAddress,
+    ) -> Result<Option<IdentityLink>, RepositoryError> {
+        let mut link: Option<IdentityLink> = None;
+        for (linked_email, server, os_user) in &self.os_users {
+            if linked_email != email.as_str() {
+                continue;
+            }
+            let identity = ExternalIdentity::new(
+                ExternalSystem::Os {
+                    server: server.clone(),
+                },
+                os_user.clone(),
+            );
+            link = Some(match link {
+                None => IdentityLink::with_external_identity(email.clone(), identity),
+                Some(mut existing) => {
+                    existing.link_external_identity(identity).unwrap();
+                    existing
+                }
+            });
+        }
+        Ok(link)
+    }
+
+    async fn find_by_external_user_id(
+        &self,
+        _system: &ExternalSystem,
+        _user_id: &str,
+    ) -> Result<Option<IdentityLink>, RepositoryError> {
+        unimplemented!("このテストでは使用しない")
+    }
+
+    async fn save(&self, _identity_link: IdentityLink) -> Result<(), RepositoryError> {
+        unimplemented!("このテストでは使用しない")
+    }
+}
+
+fn repository_with_identities(
+    identity_repo: StubIdentityLinkRepository,
+) -> (
+    GoogleCalendarUsageRepository,
+    Arc<FakeCalendarEventGateway>,
+    TempMappingPath,
+) {
+    let gateway = Arc::new(FakeCalendarEventGateway::new(vec![]));
+    let mapping_path = TempMappingPath::new();
+    let repository = GoogleCalendarUsageRepository::with_gateway(
+        gateway.clone(),
+        test_config(),
+        SERVICE_ACCOUNT_EMAIL.to_string(),
+        mapping_path.path(),
+        Arc::new(identity_repo),
+    )
+    .expect("テスト用リポジトリの構築に失敗");
+
+    (repository, gateway, mapping_path)
+}
+
+fn gpu_usage(owner: &str, device_number: u32) -> ResourceUsage {
+    use crate::domain::aggregates::resource_usage::value_objects::Gpu;
+    let now = Utc::now();
+    ResourceUsage::new(
+        crate::domain::common::EmailAddress::new(owner.to_string()).unwrap(),
+        TimePeriod::new(now, now + Duration::hours(1)).unwrap(),
+        vec![Resource::Gpu(Gpu::new(
+            "Thalys".to_string(),
+            device_number,
+            "A100 80GB PCIe".to_string(),
+        ))],
+        None,
+    )
+    .unwrap()
+}
+
+#[tokio::test]
+async fn description_includes_the_os_user_name_for_the_reserved_server() {
+    let (repository, _gateway, _mapping_path) =
+        repository_with_identities(StubIdentityLinkRepository::default().with_os_user(
+            "owner@example.com",
+            "Thalys",
+            "kkawaguchi",
+        ));
+    let usage = gpu_usage("owner@example.com", 0);
+
+    let description = repository.build_description(&usage).await;
+
+    assert!(
+        description.contains("OS: kkawaguchi"),
+        "予約したサーバーのOSユーザー名が読める形で入るべき: {description}"
+    );
+}
+
+#[tokio::test]
+async fn description_includes_the_reservation_id() {
+    let (repository, _gateway, _mapping_path) =
+        repository_with_identities(StubIdentityLinkRepository::default());
+    let usage = gpu_usage("owner@example.com", 0);
+
+    let description = repository.build_description(&usage).await;
+
+    assert!(
+        description.contains(usage.id().as_str()),
+        "予約IDが入るべき: {description}"
+    );
+}
+
+#[tokio::test]
+async fn description_omits_the_os_line_when_no_link_exists() {
+    let (repository, _gateway, _mapping_path) =
+        repository_with_identities(StubIdentityLinkRepository::default());
+    let usage = gpu_usage("unlinked@example.com", 0);
+
+    let description = repository.build_description(&usage).await;
+
+    assert!(
+        !description.contains("OS:"),
+        "紐付けがなければOS行を出さない: {description}"
+    );
+    assert!(
+        description.contains("予約者: unlinked@example.com"),
+        "予約者行は常に入る: {description}"
+    );
+}
+
+#[tokio::test]
+async fn description_uses_the_os_name_of_the_server_being_reserved() {
+    // 同じ利用者がサーバーごとに別のOSユーザー名を持つ場合、予約したサーバーの名前を使う
+    let (repository, _gateway, _mapping_path) = repository_with_identities(
+        StubIdentityLinkRepository::default()
+            .with_os_user("owner@example.com", "Thalys", "kkawaguchi")
+            .with_os_user("owner@example.com", "Freccia", "kinji"),
+    );
+    let usage = gpu_usage("owner@example.com", 0);
+
+    let description = repository.build_description(&usage).await;
+
+    assert!(description.contains("OS: kkawaguchi"), "{description}");
+    assert!(!description.contains("kinji"), "{description}");
+}
+
+#[tokio::test]
+async fn added_metadata_lines_do_not_leak_into_notes() {
+    let (repository, _gateway, _mapping_path) =
+        repository_with_identities(StubIdentityLinkRepository::default().with_os_user(
+            "owner@example.com",
+            "Thalys",
+            "kkawaguchi",
+        ));
+    let now = Utc::now();
+    let usage = ResourceUsage::new(
+        crate::domain::common::EmailAddress::new("owner@example.com".to_string()).unwrap(),
+        TimePeriod::new(now, now + Duration::hours(1)).unwrap(),
+        vec![Resource::Gpu(
+            crate::domain::aggregates::resource_usage::value_objects::Gpu::new(
+                "Thalys".to_string(),
+                0,
+                "A100 80GB PCIe".to_string(),
+            ),
+        )],
+        Some("killしても大丈夫です".to_string()),
+    )
+    .unwrap();
+
+    // 生成したdescriptionを読み戻したとき、管理セクションの行が備考に混ざらないこと
+    let description = repository.build_description(&usage).await;
+    let notes = GoogleCalendarUsageRepository::extract_notes(&description);
+
+    assert_eq!(notes.as_deref(), Some("killしても大丈夫です"));
+}
+
+/// 旧バージョンが書いたdescription（管理セクション内は予約者行のみ）
+fn legacy_description_with_markers(owner: &str, notes: &str) -> String {
+    format!(
+        "[lab-resource-manager:managed-section:begin]\n予約者: {owner}\n[lab-resource-manager:managed-section:end]\n\n{notes}"
+    )
+}
+
+/// マーカーが導入される前のdescription（1行目が予約者行）
+fn legacy_description_without_markers(owner: &str, notes: &str) -> String {
+    format!("予約者: {owner}\n{notes}")
+}
+
+#[tokio::test]
+async fn reads_reservations_written_by_older_versions_with_markers() {
+    let now = Utc::now();
+    let mut event = reservation_event(
+        "legacy-with-markers",
+        "0",
+        "placeholder@example.com",
+        now - Duration::hours(1),
+        now + Duration::hours(1),
+    );
+    event.description = Some(legacy_description_with_markers(
+        "legacy@example.com",
+        "旧形式の備考",
+    ));
+    let (repository, _gateway, _mapping_path) = repository_with(vec![event]);
+
+    let period = TimePeriod::new(now - Duration::hours(1), now + Duration::hours(1)).unwrap();
+    let found = repository.find_overlapping(&period).await.unwrap();
+
+    assert_eq!(found.len(), 1, "旧形式のイベントも予約として読めるべき");
+    assert_eq!(found[0].owner_email().as_str(), "legacy@example.com");
+    assert_eq!(found[0].notes().map(String::as_str), Some("旧形式の備考"));
+}
+
+#[tokio::test]
+async fn reads_reservations_written_before_markers_existed() {
+    let now = Utc::now();
+    let mut event = reservation_event(
+        "legacy-no-markers",
+        "1",
+        "placeholder@example.com",
+        now - Duration::hours(1),
+        now + Duration::hours(1),
+    );
+    event.description = Some(legacy_description_without_markers(
+        "ancient@example.com",
+        "マーカー導入前の備考",
+    ));
+    let (repository, _gateway, _mapping_path) = repository_with(vec![event]);
+
+    let period = TimePeriod::new(now - Duration::hours(1), now + Duration::hours(1)).unwrap();
+    let found = repository.find_overlapping(&period).await.unwrap();
+
+    assert_eq!(found.len(), 1);
+    assert_eq!(found[0].owner_email().as_str(), "ancient@example.com");
+    assert_eq!(
+        found[0].notes().map(String::as_str),
+        Some("マーカー導入前の備考")
+    );
+}
+
+#[tokio::test]
+async fn newly_written_description_round_trips() {
+    let (repository, _gateway, _mapping_path) =
+        repository_with_identities(StubIdentityLinkRepository::default().with_os_user(
+            "owner@example.com",
+            "Thalys",
+            "kkawaguchi",
+        ));
+    let now = Utc::now();
+    let usage = ResourceUsage::new(
+        crate::domain::common::EmailAddress::new("owner@example.com".to_string()).unwrap(),
+        TimePeriod::new(now, now + Duration::hours(1)).unwrap(),
+        vec![Resource::Gpu(
+            crate::domain::aggregates::resource_usage::value_objects::Gpu::new(
+                "Thalys".to_string(),
+                0,
+                "A100 80GB PCIe".to_string(),
+            ),
+        )],
+        Some("実験中".to_string()),
+    )
+    .unwrap();
+
+    // 新形式で書いたdescriptionから、予約者と備考が元の値として読み戻せること
+    let description = repository.build_description(&usage).await;
+
+    let owner = description
+        .lines()
+        .find_map(|line| line.strip_prefix("予約者: "))
+        .expect("予約者行が読めるべき");
+    assert_eq!(owner, "owner@example.com");
+    assert_eq!(
+        GoogleCalendarUsageRepository::extract_notes(&description).as_deref(),
+        Some("実験中")
+    );
+}
+
+#[tokio::test]
+async fn metadata_lines_are_not_mistaken_for_the_owner() {
+    // OS行や予約ID行が予約者として誤読されないこと（行の走査順に依存しない）
+    let (repository, _gateway, _mapping_path) =
+        repository_with_identities(StubIdentityLinkRepository::default().with_os_user(
+            "owner@example.com",
+            "Thalys",
+            "kkawaguchi",
+        ));
+    let usage = gpu_usage("owner@example.com", 0);
+
+    let description = repository.build_description(&usage).await;
+    let owner_lines: Vec<&str> = description
+        .lines()
+        .filter_map(|line| line.strip_prefix("予約者: "))
+        .collect();
+
+    assert_eq!(
+        owner_lines,
+        vec!["owner@example.com"],
+        "予約者行はちょうど1行であるべき: {description}"
     );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,17 +47,19 @@
 //! // Load configuration
 //! let config = load_config("config/resources.toml")?;
 //!
+//! // Create identity link repository for Slack user mapping
+//! let identity_repo = Arc::new(JsonFileIdentityLinkRepository::new("data/identity_links.json".into()));
+//!
 //! // Create repository and notifier
 //! let repository = Arc::new(
 //!     GoogleCalendarUsageRepository::new(
 //!         "secrets/service-account.json",
 //!         config.clone(),
 //!         "data/google_calendar_mappings.json".into(),
+//!         identity_repo.clone(),
 //!     )
 //!     .await?,
 //! );
-//! // Create identity link repository for Slack user mapping
-//! let identity_repo = Arc::new(JsonFileIdentityLinkRepository::new("data/identity_links.json".into()));
 //! // NotificationRouter automatically supports all configured notification types
 //! // (Slack, Mock, etc.) based on config/resources.toml
 //! let notifier = NotificationRouter::new(config, identity_repo);


### PR DESCRIPTION
## Why

The managed section of an event description carried only an email address:

```
[lab-resource-manager:managed-section:begin]
予約者: kawakintv.minecraft@gmail.com
[lab-resource-manager:managed-section:end]
```

Someone opening the calendar could not tell much beyond that, and had no way to refer to a booking by id when asking for it to be changed or cancelled.

## What

```
[lab-resource-manager:managed-section:begin]
予約者: kawakintv.minecraft@gmail.com
OS: kkawaguchi
予約ID: fb04101b-7f2d-4df3-8ca9-69a3bcc7293b
[lab-resource-manager:managed-section:end]

killしても大丈夫です
```

- **OS user name** — resolved from the identity link. OS user namespaces are per-server (`ExternalSystem::Os { server }`), so the link for the server actually being reserved is used. A user with different names on Thalys and Freccia gets the right one.
- **Reservation id** — the domain `UsageId`. Useful when telling Slack or an MCP agent which booking to act on.

Both lines are display-only. A missing identity link omits the OS line; a repository error logs a warning and omits it. Neither fails the save — this information exists to be read by people, not to gate writes.

Room reservations have no server, so no OS line.

### Not included

**Slack display name.** `IdentityLink` stores only the Slack user id, and `resolve_display_name` returns a mention (`<@U01ABCDEF>`) which does not render in Google Calendar. Writing a raw id would add a line nobody can read. Getting the actual name needs a `users.info` call from the repository layer, which is a heavier dependency than this feature justifies.

**Origin (Slack / MCP / usage detection).** `ResourceUsage` does not carry how it was created. Post-hoc reservations are currently identifiable only by a magic string in `notes`, and having the repository interpret `notes` would be the wrong direction. Doing this properly means adding an `origin` to the aggregate — worth doing, since it would also free the notes field that the system currently occupies, but it is a model change and belongs in its own PR.

## Backward compatibility

Reading older data works unchanged — the owner is extracted by scanning lines for the `予約者: ` prefix, which never depended on position, and notes extraction already handled three shapes (markers, pre-marker single line, no app metadata at all).

Rolling back is also safe. The new lines sit **inside** the managed markers, so an older build still finds the owner line and still strips the whole section out of the notes. No stray metadata leaks into a user's notes field.

Four tests cover this explicitly: descriptions written by older versions with markers, descriptions from before markers existed, a round trip through the new format, and a check that exactly one line parses as the owner.

## Test plan

- [x] 5 tests written to fail first (OS line present, reservation id present, OS line omitted without a link, per-server name selection, metadata not leaking into notes)
- [x] 4 backward-compatibility tests
- [x] `cargo test` — 119 passed
- [x] `cargo clippy --workspace --all-targets --all-features -- -Dwarnings` — clean
- [x] `cargo build --workspace --all-targets --all-features` with `RUSTFLAGS=-D warnings` — clean
- [x] `cargo fmt --all --check`
- [ ] Not verified against the live calendar. Existing events keep their current description until the next update to that event, so the change rolls out gradually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KHaZgaoJcQjDGXZF9PJ9S
