### PR TITLE
fix: detect conflicts against reservations that have already ended

### DIFF
--- a/src/domain/ports/repositories/resource_usage.rs
+++ b/src/domain/ports/repositories/resource_usage.rs
@@ -9,6 +9,17 @@ use crate::domain::{
 use async_trait::async_trait;
 
 /// ResourceUsage集約のリポジトリポート
+///
+/// # 予約として扱う範囲
+/// 永続化層のレコードのうち、`ResourceUsage`として解釈できるものだけが予約である。
+/// 解釈できないレコードは予約ではなく、このモデルの外にある。検索結果に現れないのは
+/// 取りこぼしではなく、予約ではないものを返さないという意味である。
+///
+/// 永続化層が人の手による編集を受け付ける場合、予約の形式に沿わないレコードは
+/// 避けられない。それを予約として復元しようとはしない。
+///
+/// 予約されないまま使われるリソースは、実利用の観測（`ResourceUsageObserver`）が
+/// 扱う領域である。
 #[async_trait]
 pub trait ResourceUsageRepository {
     /// IDでResourceUsageを検索

--- a/src/domain/ports/repositories/resource_usage.rs
+++ b/src/domain/ports/repositories/resource_usage.rs
@@ -26,6 +26,10 @@ pub trait ResourceUsageRepository {
     async fn find_future(&self) -> Result<Vec<ResourceUsage>, RepositoryError>;
 
     /// 指定期間と重複するResourceUsageを検索
+    ///
+    /// 終了済みのリソース使用も含めて返します。過去の期間に対する予約（実利用検知に
+    /// もとづく事後予約など）でも競合を検出できる必要があるため、実装は
+    /// 「現在時刻より後に終わるもの」で絞り込んではいけません。
     async fn find_overlapping(
         &self,
         time_period: &TimePeriod,

--- a/src/domain/services/resource_usage/conflict_checker.rs
+++ b/src/domain/services/resource_usage/conflict_checker.rs
@@ -5,6 +5,14 @@ use crate::domain::services::resource_usage::errors::{ConflictCheckError, Resour
 /// リソース競合チェックサービス
 ///
 /// 指定された時間帯とリソースが既存の予約と競合しないかをチェックする
+///
+/// # 判定の範囲
+/// 判定の対象は予約である。永続化層にあって予約として解釈されないレコードは
+/// 予約ではないため、競合の対象にならない（`ResourceUsageRepository`を参照）。
+///
+/// したがって競合なしとは「予約と重ならない」ことであり、そのリソースが実際に
+/// 使われていないことは意味しない。予約されないまま使われるリソースは
+/// 実利用の観測側で扱う。
 #[derive(Debug, Clone, Default)]
 pub struct ResourceConflictChecker;
 

--- a/src/infrastructure/repositories/resource_usage/google_calendar/event_gateway.rs
+++ b/src/infrastructure/repositories/resource_usage/google_calendar/event_gateway.rs
@@ -8,6 +8,9 @@ use google_calendar3::{
     hyper_util::client::legacy::connect::HttpConnector,
 };
 
+/// 1ページあたりの最大取得件数（Google Calendar APIの上限値）
+const MAX_RESULTS_PER_PAGE: i32 = 2500;
+
 /// Google Calendarのイベント操作
 ///
 /// リポジトリは「どの期間を問い合わせるか」「取得したイベントをどう解釈するか」を担い、
@@ -67,18 +70,42 @@ impl CalendarEventGateway for GoogleCalendarEventGateway {
         time_min: DateTime<Utc>,
         time_max: Option<DateTime<Utc>>,
     ) -> Result<Vec<Event>, RepositoryError> {
-        let mut call = self.hub.events().list(calendar_id).time_min(time_min);
+        let mut all_events = Vec::new();
+        let mut page_token: Option<String> = None;
 
-        if let Some(time_max) = time_max {
-            call = call.time_max(time_max);
+        // 1ページに収まらない場合、続きのページを取得しないとイベントを取りこぼす
+        loop {
+            let mut call = self
+                .hub
+                .events()
+                .list(calendar_id)
+                .time_min(time_min)
+                // 繰り返しイベントを個々の予定へ展開する。展開しないと繰り返しの
+                // 2回目以降が取得できず、予約として扱えない
+                .single_events(true)
+                .max_results(MAX_RESULTS_PER_PAGE);
+
+            if let Some(time_max) = time_max {
+                call = call.time_max(time_max);
+            }
+
+            if let Some(token) = &page_token {
+                call = call.page_token(token);
+            }
+
+            let (_response, events) = call.doit().await.map_err(|e| {
+                RepositoryError::ConnectionError(format!("Calendar API error: {}", e))
+            })?;
+
+            all_events.extend(events.items.unwrap_or_default());
+
+            match events.next_page_token {
+                Some(token) => page_token = Some(token),
+                None => break,
+            }
         }
 
-        let result = call
-            .doit()
-            .await
-            .map_err(|e| RepositoryError::ConnectionError(format!("Calendar API error: {}", e)))?;
-
-        Ok(result.1.items.unwrap_or_default())
+        Ok(all_events)
     }
 
     async fn get_event(

--- a/src/infrastructure/repositories/resource_usage/google_calendar/mod.rs
+++ b/src/infrastructure/repositories/resource_usage/google_calendar/mod.rs
@@ -3,5 +3,7 @@
 mod event_gateway;
 mod id_mapper;
 mod repository;
+#[cfg(test)]
+mod repository_tests;
 
 pub use repository::GoogleCalendarUsageRepository;

--- a/src/infrastructure/repositories/resource_usage/google_calendar/repository.rs
+++ b/src/infrastructure/repositories/resource_usage/google_calendar/repository.rs
@@ -9,7 +9,7 @@ use crate::domain::common::EmailAddress;
 use crate::domain::ports::repositories::{RepositoryError, ResourceUsageRepository};
 use crate::infrastructure::config::ResourceConfig;
 use async_trait::async_trait;
-use chrono::{Duration, Utc};
+use chrono::{DateTime, Utc};
 use google_calendar3::{
     CalendarHub,
     api::Event,
@@ -29,6 +29,17 @@ const MANAGED_SECTION_BEGIN: &str = "[lab-resource-manager:managed-section:begin
 
 /// アプリが管理するセクションの終了マーカー。このマーカーより後ろが備考として扱われる。
 const MANAGED_SECTION_END: &str = "[lab-resource-manager:managed-section:end]";
+
+/// キャンセル済みイベントのstatus値
+const EVENT_STATUS_CANCELLED: &str = "cancelled";
+
+/// イベントが有効な（キャンセルされていない）予約かどうか
+///
+/// 繰り返しイベントを個々の予定に展開して取得すると、削除された回が
+/// `status: cancelled`として返ることがある。これは予約として扱わない。
+fn is_active_event(event: &Event) -> bool {
+    event.status.as_deref() != Some(EVENT_STATUS_CANCELLED)
+}
 
 /// Google Calendar APIを使用したResourceUsageリポジトリ実装
 pub struct GoogleCalendarUsageRepository {
@@ -77,66 +88,91 @@ impl GoogleCalendarUsageRepository {
         })
     }
 
-    /// すべてのカレンダーから未来のイベントを取得
+    /// ゲートウェイを差し替えてリポジトリを構築する（テスト用）
+    #[cfg(test)]
+    pub(super) fn with_gateway(
+        gateway: Arc<dyn CalendarEventGateway>,
+        config: ResourceConfig,
+        service_account_email: String,
+        id_mappings_path: std::path::PathBuf,
+    ) -> Result<Self, RepositoryError> {
+        Ok(Self {
+            gateway,
+            config,
+            service_account_email,
+            id_mapper: Arc::new(IdMapper::new(id_mappings_path)?),
+        })
+    }
+
+    /// 管理対象のカレンダー一覧
+    /// 戻り値: (calendar_id, resource_name)
+    fn calendars(&self) -> Vec<(String, String)> {
+        self.config
+            .servers
+            .iter()
+            .map(|server| (server.calendar_id.clone(), server.name.clone()))
+            .chain(
+                self.config
+                    .rooms
+                    .iter()
+                    .map(|room| (room.calendar_id.clone(), room.name.clone())),
+            )
+            .collect()
+    }
+
+    /// すべてのカレンダーから、指定期間に重なるイベントを取得
+    ///
+    /// `time_min`は「イベントの終了時刻がこれより後」、`time_max`は「イベントの開始時刻が
+    /// これより前」を意味する。どの期間を対象とするかは呼び出し側が決める。
+    ///
     /// 戻り値: (Event, calendar_id, resource_name)
-    async fn fetch_future_events(&self) -> Result<Vec<(Event, String, String)>, RepositoryError> {
+    async fn fetch_events(
+        &self,
+        time_min: DateTime<Utc>,
+        time_max: Option<DateTime<Utc>>,
+    ) -> Result<Vec<(Event, String, String)>, RepositoryError> {
         let mut all_events = Vec::new();
 
-        // 各サーバーカレンダーから取得
-        for server in &self.config.servers {
-            let events = self.fetch_events_from_calendar(&server.calendar_id).await?;
-            all_events.extend(
-                events
-                    .into_iter()
-                    .map(|e| (e, server.calendar_id.clone(), server.name.clone())),
-            );
-        }
+        for (calendar_id, resource_name) in self.calendars() {
+            let events = self
+                .gateway
+                .list_events(&calendar_id, time_min, time_max)
+                .await?;
 
-        // 部屋カレンダーから取得
-        for room in &self.config.rooms {
-            let events = self.fetch_events_from_calendar(&room.calendar_id).await?;
             all_events.extend(
                 events
                     .into_iter()
-                    .map(|e| (e, room.calendar_id.clone(), room.name.clone())),
+                    .filter(is_active_event)
+                    .map(|event| (event, calendar_id.clone(), resource_name.clone())),
             );
         }
 
         Ok(all_events)
     }
 
-    /// 特定のカレンダーから未来のイベント（進行中および今後予定されているもの）を取得
-    async fn fetch_events_from_calendar(
-        &self,
-        calendar_id: &str,
-    ) -> Result<Vec<Event>, RepositoryError> {
-        // 過去24時間分も取得して、終了時刻でフィルタリングする
-        // time_minを開始時刻で制限すると、現在進行中のイベント（開始時刻が過去）が除外されてしまう
-        let time_min = Utc::now() - Duration::hours(24);
-
-        let events = self
-            .gateway
-            .list_events(calendar_id, time_min, None)
-            .await?;
-
-        let now = Utc::now();
-
-        // 終了時刻が現在時刻より後のイベントのみを返す
-        // これにより、進行中または未来のイベントのみが対象となり、
-        // 完了したイベントが誤って削除通知されるのを防ぐ
-        let filtered_events: Vec<Event> = events
+    /// 取得したイベント群をResourceUsageへ変換する
+    ///
+    /// 予約として解釈できないイベント（カレンダー上で直接作られた自由記述のイベントなど）は
+    /// 警告を残して飛ばす。1件の解釈失敗で予約機能全体を止めないための判断。
+    fn parse_events(&self, events: Vec<(Event, String, String)>) -> Vec<ResourceUsage> {
+        events
             .into_iter()
-            .filter(|event| {
-                event
-                    .end
-                    .as_ref()
-                    .and_then(|e| e.date_time.as_ref())
-                    .map(|end_time| *end_time > now)
-                    .unwrap_or(false)
+            .filter_map(|(event, calendar_id, resource_context)| {
+                let event_id = event.id.clone().unwrap_or_default();
+                match self.parse_event(event, &calendar_id, &resource_context) {
+                    Ok(usage) => Some(usage),
+                    Err(e) => {
+                        tracing::warn!(
+                            "イベントを予約として解釈できませんでした: calendar_id={}, event_id={}, error={}",
+                            calendar_id,
+                            event_id,
+                            e
+                        );
+                        None
+                    }
+                }
             })
-            .collect();
-
-        Ok(filtered_events)
+            .collect()
     }
 
     /// イベントをResourceUsageに変換
@@ -461,25 +497,10 @@ impl GoogleCalendarUsageRepository {
         &self,
         event_id: &str,
     ) -> Result<Option<ResourceUsage>, RepositoryError> {
-        // すべてのカレンダーIDを取得
-        let mut calendar_ids: Vec<String> = self
-            .config
-            .servers
-            .iter()
-            .map(|server| server.calendar_id.clone())
-            .collect();
-
-        // 部屋のカレンダーも追加
-        for room in &self.config.rooms {
-            calendar_ids.push(room.calendar_id.clone());
-        }
-
         // 各カレンダーでイベントの検索を試みる
-        for calendar_id in calendar_ids {
+        for (calendar_id, resource_context) in self.calendars() {
             match self.gateway.get_event(&calendar_id, event_id).await? {
                 Some(event) => {
-                    // リソースコンテキストを取得
-                    let resource_context = self.get_resource_context(&calendar_id)?;
                     // イベントをパース（この時点で新しいマッピングが作成される）
                     let usage = self.parse_event(event, &calendar_id, &resource_context)?;
                     return Ok(Some(usage));
@@ -499,21 +520,8 @@ impl GoogleCalendarUsageRepository {
     ///
     /// 全カレンダーから該当するイベントを検索して削除します。
     async fn delete_by_event_id(&self, event_id: &str) -> Result<(), RepositoryError> {
-        // すべてのカレンダーIDを取得
-        let mut calendar_ids: Vec<String> = self
-            .config
-            .servers
-            .iter()
-            .map(|server| server.calendar_id.clone())
-            .collect();
-
-        // 部屋のカレンダーも追加
-        for room in &self.config.rooms {
-            calendar_ids.push(room.calendar_id.clone());
-        }
-
         // 各カレンダーでイベントの削除を試みる
-        for calendar_id in calendar_ids {
+        for (calendar_id, _resource_name) in self.calendars() {
             match self.gateway.delete_event(&calendar_id, event_id).await {
                 Ok(_) => {
                     tracing::info!(
@@ -613,37 +621,28 @@ impl ResourceUsageRepository for GoogleCalendarUsageRepository {
     }
 
     async fn find_future(&self) -> Result<Vec<ResourceUsage>, RepositoryError> {
-        let events = self.fetch_future_events().await?;
+        // 終了時刻が現在より後のイベントに限る。開始時刻では絞らないため、
+        // 進行中のイベント（開始時刻が過去）も含まれる。
+        let events = self.fetch_events(Utc::now(), None).await?;
 
-        let mut usages = Vec::new();
-        for (event, calendar_id, context) in events {
-            match self.parse_event(event, &calendar_id, &context) {
-                Ok(usage) => usages.push(usage),
-                Err(e) => {
-                    eprintln!("⚠️  イベントパースエラー: {}", e); // TODO@KinjiKawaguchi: エラーハンドリングの改善
-                }
-            }
-        }
-
-        Ok(usages)
+        Ok(self.parse_events(events))
     }
 
     /// 指定期間と重複するResourceUsageを検索
     ///
-    /// # パフォーマンスに関する注意
-    /// 現在の実装では、すべての未来のイベントを取得してからメモリ上でフィルタリングしています。
-    /// Google Calendar APIには時間範囲での検索機能がありますが、複数カレンダーにまたがる
-    /// 検索を効率的に行うための十分なクエリ機能がないため、この実装を採用しています。
-    ///
-    /// 将来的な改善案:
-    /// - 各カレンダーに対して時間範囲クエリを並列実行
-    /// - 結果のキャッシング（短時間の重複チェックに有効）
+    /// 対象期間そのものをカレンダーに問い合わせる。`find_future`は使わない。
+    /// 事後予約のように過去の期間を予約する場合、相手の予約が既に終了していても
+    /// 競合は競合であり、終了済みを除外すると重複予約を許してしまう。
     async fn find_overlapping(
         &self,
         time_period: &TimePeriod,
     ) -> Result<Vec<ResourceUsage>, RepositoryError> {
-        let all_usages = self.find_future().await?;
-        Ok(all_usages
+        let events = self
+            .fetch_events(time_period.start(), Some(time_period.end()))
+            .await?;
+
+        Ok(self
+            .parse_events(events)
             .into_iter()
             .filter(|usage| usage.time_period().overlaps_with(time_period))
             .collect())
@@ -651,14 +650,7 @@ impl ResourceUsageRepository for GoogleCalendarUsageRepository {
 
     /// 特定のユーザーが所有するResourceUsageを検索
     ///
-    /// # パフォーマンスに関する注意
-    /// 現在の実装では、すべての未来のイベントを取得してからメモリ上でフィルタリングしています。
-    /// Google Calendar APIには所有者による検索機能がありますが、複数カレンダーにまたがる
-    /// 検索と、descriptionフィールドからの所有者抽出が必要なため、この実装を採用しています。
-    ///
-    /// 将来的な改善案:
-    /// - ユーザーごとのイベントキャッシング
-    /// - 定期的なバックグラウンド同期によるローカルインデックス構築
+    /// 進行中および今後の予約のみを対象とする（終了済みの予約は返さない）。
     async fn find_by_owner(
         &self,
         owner_email: &EmailAddress,

--- a/src/infrastructure/repositories/resource_usage/google_calendar/repository_tests.rs
+++ b/src/infrastructure/repositories/resource_usage/google_calendar/repository_tests.rs
@@ -1,0 +1,360 @@
+//! `GoogleCalendarUsageRepository`の検索系メソッドのテスト
+//!
+//! カレンダーAPIへのアクセスは`CalendarEventGateway`のテストダブルに差し替え、
+//! 「どの期間を問い合わせるか」「取得したイベントをどう解釈するか」を検証する。
+
+use super::event_gateway::CalendarEventGateway;
+use super::repository::GoogleCalendarUsageRepository;
+use crate::domain::aggregates::resource_usage::value_objects::TimePeriod;
+use crate::domain::ports::repositories::{RepositoryError, ResourceUsageRepository};
+use crate::infrastructure::config::{DeviceConfig, ResourceConfig, ServerConfig};
+use async_trait::async_trait;
+use chrono::{DateTime, Duration, Utc};
+use google_calendar3::api::{Event, EventCreator, EventDateTime};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+const SERVICE_ACCOUNT_EMAIL: &str = "service-account@example.com";
+const CALENDAR_ID: &str = "thalys-calendar-id";
+
+/// ゲートウェイが受け取った問い合わせ内容
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ListQuery {
+    calendar_id: String,
+    time_min: DateTime<Utc>,
+    time_max: Option<DateTime<Utc>>,
+}
+
+/// 固定のイベント集合を返し、受け取った問い合わせを記録するテストダブル
+///
+/// `list_events`はGoogle Calendar APIの絞り込み意味論を模倣する。
+/// すなわち終了時刻が`time_min`より後、かつ（`time_max`指定時は）開始時刻が
+/// `time_max`より前のイベントだけを返す。
+struct FakeCalendarEventGateway {
+    events: Vec<Event>,
+    queries: Mutex<Vec<ListQuery>>,
+}
+
+impl FakeCalendarEventGateway {
+    fn new(events: Vec<Event>) -> Self {
+        Self {
+            events,
+            queries: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn queries(&self) -> Vec<ListQuery> {
+        self.queries.lock().unwrap().clone()
+    }
+}
+
+fn event_start(event: &Event) -> DateTime<Utc> {
+    event
+        .start
+        .as_ref()
+        .and_then(|s| s.date_time)
+        .expect("テストイベントには開始時刻が必要")
+}
+
+fn event_end(event: &Event) -> DateTime<Utc> {
+    event
+        .end
+        .as_ref()
+        .and_then(|e| e.date_time)
+        .expect("テストイベントには終了時刻が必要")
+}
+
+#[async_trait]
+impl CalendarEventGateway for FakeCalendarEventGateway {
+    async fn list_events(
+        &self,
+        calendar_id: &str,
+        time_min: DateTime<Utc>,
+        time_max: Option<DateTime<Utc>>,
+    ) -> Result<Vec<Event>, RepositoryError> {
+        self.queries.lock().unwrap().push(ListQuery {
+            calendar_id: calendar_id.to_string(),
+            time_min,
+            time_max,
+        });
+
+        Ok(self
+            .events
+            .iter()
+            .filter(|event| event_end(event) > time_min)
+            .filter(|event| time_max.is_none_or(|max| event_start(event) < max))
+            .cloned()
+            .collect())
+    }
+
+    async fn get_event(
+        &self,
+        _calendar_id: &str,
+        _event_id: &str,
+    ) -> Result<Option<Event>, RepositoryError> {
+        unimplemented!("このテストでは使用しない")
+    }
+
+    async fn insert_event(
+        &self,
+        _calendar_id: &str,
+        _event: Event,
+    ) -> Result<Event, RepositoryError> {
+        unimplemented!("このテストでは使用しない")
+    }
+
+    async fn update_event(
+        &self,
+        _calendar_id: &str,
+        _event_id: &str,
+        _event: Event,
+    ) -> Result<(), RepositoryError> {
+        unimplemented!("このテストでは使用しない")
+    }
+
+    async fn delete_event(
+        &self,
+        _calendar_id: &str,
+        _event_id: &str,
+    ) -> Result<(), RepositoryError> {
+        unimplemented!("このテストでは使用しない")
+    }
+}
+
+/// テスト終了時に自動削除される一時ファイルパス
+struct TempMappingPath(PathBuf);
+
+impl TempMappingPath {
+    fn new() -> Self {
+        Self(std::env::temp_dir().join(format!("lrm-id-mappings-{}.json", uuid::Uuid::new_v4())))
+    }
+
+    fn path(&self) -> PathBuf {
+        self.0.clone()
+    }
+}
+
+impl Drop for TempMappingPath {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+fn test_config() -> ResourceConfig {
+    ResourceConfig {
+        servers: vec![ServerConfig {
+            name: "Thalys".to_string(),
+            calendar_id: CALENDAR_ID.to_string(),
+            devices: vec![
+                DeviceConfig {
+                    id: 0,
+                    model: "A100 80GB PCIe".to_string(),
+                },
+                DeviceConfig {
+                    id: 1,
+                    model: "A100 80GB PCIe".to_string(),
+                },
+            ],
+            notifications: vec![],
+        }],
+        rooms: vec![],
+    }
+}
+
+/// アプリが作成した予約イベント（予約者はdescriptionのアプリ管理セクションに入る）
+fn reservation_event(
+    event_id: &str,
+    gpu_spec: &str,
+    owner_email: &str,
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+) -> Event {
+    Event {
+        id: Some(event_id.to_string()),
+        summary: Some(gpu_spec.to_string()),
+        description: Some(format!(
+            "[lab-resource-manager:managed-section:begin]\n予約者: {}\n[lab-resource-manager:managed-section:end]",
+            owner_email
+        )),
+        creator: Some(EventCreator {
+            email: Some(SERVICE_ACCOUNT_EMAIL.to_string()),
+            ..Default::default()
+        }),
+        start: Some(EventDateTime {
+            date_time: Some(start),
+            ..Default::default()
+        }),
+        end: Some(EventDateTime {
+            date_time: Some(end),
+            ..Default::default()
+        }),
+        status: Some("confirmed".to_string()),
+        ..Default::default()
+    }
+}
+
+fn repository_with(
+    events: Vec<Event>,
+) -> (
+    GoogleCalendarUsageRepository,
+    Arc<FakeCalendarEventGateway>,
+    TempMappingPath,
+) {
+    let gateway = Arc::new(FakeCalendarEventGateway::new(events));
+    let mapping_path = TempMappingPath::new();
+    let repository = GoogleCalendarUsageRepository::with_gateway(
+        gateway.clone(),
+        test_config(),
+        SERVICE_ACCOUNT_EMAIL.to_string(),
+        mapping_path.path(),
+    )
+    .expect("テスト用リポジトリの構築に失敗");
+
+    (repository, gateway, mapping_path)
+}
+
+#[tokio::test]
+async fn find_overlapping_includes_reservation_that_already_ended() {
+    let now = Utc::now();
+    // 5時間前に始まり3時間前に終わった予約（事後予約の承諾が遅れた場合に相手となるもの）
+    let existing = reservation_event(
+        "already-ended",
+        "0",
+        "owner@example.com",
+        now - Duration::hours(5),
+        now - Duration::hours(3),
+    );
+    let (repository, _gateway, _mapping_path) = repository_with(vec![existing]);
+
+    // 4時間前〜2時間前を予約しようとすると、上の予約と重なる
+    let period = TimePeriod::new(now - Duration::hours(4), now - Duration::hours(2)).unwrap();
+
+    let overlapping = repository.find_overlapping(&period).await.unwrap();
+
+    assert_eq!(
+        overlapping.len(),
+        1,
+        "終了時刻が過去の予約も競合チェックの対象に含めるべき"
+    );
+}
+
+#[tokio::test]
+async fn find_overlapping_queries_exactly_the_requested_period() {
+    let now = Utc::now();
+    let (repository, gateway, _mapping_path) = repository_with(vec![]);
+    let period = TimePeriod::new(now - Duration::hours(4), now - Duration::hours(2)).unwrap();
+
+    repository.find_overlapping(&period).await.unwrap();
+
+    let queries = gateway.queries();
+    assert_eq!(
+        queries.len(),
+        1,
+        "サーバーカレンダー1件分の問い合わせが行われる"
+    );
+    assert_eq!(
+        queries[0].time_min,
+        period.start(),
+        "問い合わせの下限は対象期間の開始時刻であるべき"
+    );
+    assert_eq!(
+        queries[0].time_max,
+        Some(period.end()),
+        "問い合わせの上限は対象期間の終了時刻であるべき"
+    );
+}
+
+#[tokio::test]
+async fn find_overlapping_ignores_cancelled_events() {
+    let now = Utc::now();
+    let mut cancelled = reservation_event(
+        "cancelled-event",
+        "0",
+        "owner@example.com",
+        now - Duration::hours(1),
+        now + Duration::hours(1),
+    );
+    cancelled.status = Some("cancelled".to_string());
+    let (repository, _gateway, _mapping_path) = repository_with(vec![cancelled]);
+
+    let period = TimePeriod::new(now - Duration::hours(1), now + Duration::hours(1)).unwrap();
+
+    let overlapping = repository.find_overlapping(&period).await.unwrap();
+
+    assert!(
+        overlapping.is_empty(),
+        "キャンセル済みイベントは予約として扱わない"
+    );
+}
+
+#[tokio::test]
+async fn find_overlapping_skips_unparsable_events_but_keeps_the_rest() {
+    let now = Utc::now();
+    // GPUデバイス仕様として解釈できないタイトル（カレンダー上で直接作られた場合など）
+    let unparsable = reservation_event(
+        "unparsable",
+        "実験中",
+        "owner@example.com",
+        now - Duration::hours(1),
+        now + Duration::hours(1),
+    );
+    let valid = reservation_event(
+        "valid",
+        "1",
+        "owner@example.com",
+        now - Duration::hours(1),
+        now + Duration::hours(1),
+    );
+    let (repository, _gateway, _mapping_path) = repository_with(vec![unparsable, valid]);
+
+    let period = TimePeriod::new(now - Duration::hours(1), now + Duration::hours(1)).unwrap();
+
+    let overlapping = repository.find_overlapping(&period).await.unwrap();
+
+    assert_eq!(
+        overlapping.len(),
+        1,
+        "解釈できないイベントは飛ばし、残りは返すべき"
+    );
+}
+
+#[tokio::test]
+async fn find_future_excludes_reservation_that_already_ended() {
+    let now = Utc::now();
+    let ended = reservation_event(
+        "already-ended",
+        "0",
+        "owner@example.com",
+        now - Duration::hours(5),
+        now - Duration::hours(3),
+    );
+    let (repository, _gateway, _mapping_path) = repository_with(vec![ended]);
+
+    let future = repository.find_future().await.unwrap();
+
+    assert!(
+        future.is_empty(),
+        "終了済みの予約は今後の予約として扱わない"
+    );
+}
+
+#[tokio::test]
+async fn find_future_keeps_ongoing_reservation() {
+    let now = Utc::now();
+    let ongoing = reservation_event(
+        "ongoing",
+        "0",
+        "owner@example.com",
+        now - Duration::hours(5),
+        now + Duration::hours(1),
+    );
+    let (repository, _gateway, _mapping_path) = repository_with(vec![ongoing]);
+
+    let future = repository.find_future().await.unwrap();
+
+    assert_eq!(
+        future.len(),
+        1,
+        "開始時刻が過去でも進行中の予約は含めるべき"
+    );
+}


### PR DESCRIPTION
## Why

Duplicate reservations exist in the lab calendars. `find_overlapping` delegated to `find_future`, which only returns events whose end time is later than now. That filter exists so completed events are not mistaken for deletions when sending change notifications — it is not a statement about conflicts. Any reservation that had **already ended** was therefore invisible to the conflict check.

Post-hoc reservations (`GPU実利用検知による事後予約`) cover a past interval by construction: `start = active_since`. The longer a user waits before pressing an accept button, the more likely one side of the comparison has already ended, and the duplicate goes straight through.

### Duplicates found

| Resource | Overlapping window | Events |
|---|---|---|
| Thalys GPU#1 | 7/25 22:18:30–7/26 01:18:30 | `mcr65m8`, `e6iuqss`, `ns2bc5i` (3 identical) |
| Thalys GPU#4 | 7/25 22:18:39–7/26 01:18:39 | `cr5er94`, `p2euqq0` |
| Thalys GPU#0 | from 7/25 22:23:07 | `cbn5c24` (2h), `b9ah9sp` (12h) |
| Thalys GPU#0 | 7/26 16:18–17:18 | `g27il11` (normal booking) vs `b5h9l28` (post-hoc) |
| Freccia GPU#1 | 7/25 21:39–7/26 00:00 | `qfjaj5f` × `k839bu6`; `nvekssom` identical to `k839bu6` |
| Freccia GPU#6 | 7/27 07:13:56–07:52:55 | `l5i7920` × `l4qqusn` |
| Freccia GPU#5 | 7/27 07:22:54–07:46:27 | `m3t8lq2` × `0ds8n4m` |
| Freccia GPU#4 | 7/27 08:06:23–08:38:54 | `o05pk2c` × `906sodh` |

In every case the creation timestamp is later than the other reservation's end time. `k839bu6` was created 7/26 00:03 JST while `qfjaj5f` ended 7/26 00:00 JST — three minutes was enough to open the hole.

Three of the Freccia rows still have one live side, which is why the MCP listing (future reservations only) shows no duplicates: the other side has ended and dropped out of the list.

## What

- `find_overlapping` queries the requested interval directly (`time_min = period.start`, `time_max = period.end`) instead of reusing `find_future`. Ended reservations are included. The port documents that implementations must not filter by "ends after now".
- `find_future` passes `time_min = now`. The previous `now - 24h` workaround and the local `end > now` filter are both gone — the API's `timeMin` already means "ends after this".
- `list_events` follows `nextPageToken`. A single `doit()` silently capped results at 250 per calendar.
- `single_events(true)` expands recurring events. Without it only the parent is returned, and if the parent's end time is past, the entire series disappears from the check.
- Cancelled events are no longer treated as reservations.
- Parse failures log through `tracing::warn!` with calendar and event id, instead of `eprintln!`.

## Test plan

- [x] 6 new tests in `repository_tests.rs`, driven by a `CalendarEventGateway` double that mimics the API's filtering semantics. Three were confirmed failing first: ended reservations excluded from the result, wrong query range (`now - 24h` instead of the period start), cancelled events counted as reservations.
- [x] `cargo test` — 99 passed
- [x] `cargo clippy --all-targets` — no warnings
- [x] `cargo fmt --check`
- [ ] Pagination and recurring-event expansion have no automated coverage — they live in the API adapter. With 4 calendars and roughly 35 events/month the 250 cap is far away, so both are hardening rather than active bugs. Worth a manual check in the lab environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KHaZgaoJcQjDGXZF9PJ9S

---

**Note:** this PR now also carries the documentation commit from #103, which was merged into this branch before #102 lost its base branch and was auto-closed. #102 and #103 are superseded by this PR; the content is unchanged.
