### PR TITLE
refactor: derive calendar event ids from reservation ids

### DIFF
--- a/src/infrastructure/repositories/resource_usage/google_calendar/id_mapper.rs
+++ b/src/infrastructure/repositories/resource_usage/google_calendar/id_mapper.rs
@@ -1,4 +1,11 @@
 //! Google Calendar Event ID マッピング (内部実装)
+//!
+//! イベントIDは予約IDから決定的に導出されるため、通常は対応表を必要としない。
+//! 例外は、イベントIDをアプリが指定するようになる前に作られた予約である。それらは
+//! Google側が採番したイベントIDを持ち、予約IDから導出できない。この対応表は
+//! そうした予約を解決するために読み取り専用で残している。
+//!
+//! TODO(#111): 次のメジャーリリースでこのモジュールと`GOOGLE_CALENDAR_MAPPINGS_FILE`を削除する
 
 use crate::domain::ports::repositories::RepositoryError;
 use serde::{Deserialize, Serialize};
@@ -15,7 +22,9 @@ pub(super) struct ExternalId {
     pub event_id: String,
 }
 
-/// Domain ID と Google Calendar Event ID のマッピングを管理
+/// 予約IDから導出できないイベントIDを解決するための対応表
+///
+/// 新しい対応は追加されない。読み取りのみを担う。
 pub(super) struct IdMapper {
     file_path: PathBuf,
     mappings: Arc<Mutex<HashMap<String, ExternalId>>>,

--- a/src/infrastructure/repositories/resource_usage/google_calendar/id_mapper.rs
+++ b/src/infrastructure/repositories/resource_usage/google_calendar/id_mapper.rs
@@ -45,31 +45,6 @@ impl IdMapper {
         })
     }
 
-    /// マッピングを保存
-    pub(super) fn save_mapping(
-        &self,
-        domain_id: &str,
-        external_id: ExternalId,
-    ) -> Result<(), RepositoryError> {
-        let mut mappings = self.mappings.lock().unwrap();
-        let mut reverse_mappings = self.reverse_mappings.lock().unwrap();
-
-        // 既存のマッピングがある場合は逆引きマップから削除
-        if let Some(old_external_id) = mappings.get(domain_id) {
-            reverse_mappings.remove(&old_external_id.event_id);
-        }
-
-        // 新しいマッピングを追加
-        reverse_mappings.insert(external_id.event_id.clone(), domain_id.to_string());
-        mappings.insert(domain_id.to_string(), external_id);
-
-        drop(mappings);
-        drop(reverse_mappings);
-
-        self.save_to_file()?;
-        Ok(())
-    }
-
     /// Domain ID から外部ID を取得
     pub(super) fn get_external_id(
         &self,

--- a/src/infrastructure/repositories/resource_usage/google_calendar/repository.rs
+++ b/src/infrastructure/repositories/resource_usage/google_calendar/repository.rs
@@ -45,6 +45,9 @@ const RESERVATION_ID_LINE_PREFIX: &str = "予約ID: ";
 /// イベントIDに使える文字はbase32hex（英小文字a-vと数字0-9）に限られるため、
 /// UUIDのハイフンを除いた表現を用いる。予約IDとイベントIDが決定的に対応するので、
 /// 両者の対応表を持たなくても相互に解決できる。
+///
+/// イベントIDをアプリが指定するようになる前に作られた予約は、Google側が採番した
+/// イベントIDを持つためこの導出が使えない。それらは`IdMapper`が解決する。
 fn event_id_for(usage_id: &UsageId) -> String {
     usage_id.as_str().replace('-', "")
 }

--- a/src/infrastructure/repositories/resource_usage/google_calendar/repository.rs
+++ b/src/infrastructure/repositories/resource_usage/google_calendar/repository.rs
@@ -40,6 +40,15 @@ const OS_USER_LINE_PREFIX: &str = "OS: ";
 /// 予約IDの行の接頭辞
 const RESERVATION_ID_LINE_PREFIX: &str = "予約ID: ";
 
+/// 予約IDからカレンダーのイベントIDを導出する
+///
+/// イベントIDに使える文字はbase32hex（英小文字a-vと数字0-9）に限られるため、
+/// UUIDのハイフンを除いた表現を用いる。予約IDとイベントIDが決定的に対応するので、
+/// 両者の対応表を持たなくても相互に解決できる。
+fn event_id_for(usage_id: &UsageId) -> String {
+    usage_id.as_str().replace('-', "")
+}
+
 /// キャンセル済みイベントのstatus値
 const EVENT_STATUS_CANCELLED: &str = "cancelled";
 
@@ -251,7 +260,7 @@ impl GoogleCalendarUsageRepository {
             .into_iter()
             .filter_map(|(event, calendar_id, resource_context)| {
                 let event_id = event.id.clone().unwrap_or_default();
-                match self.parse_event(event, &calendar_id, &resource_context) {
+                match self.parse_event(event, &resource_context) {
                     Ok(usage) => Some(usage),
                     Err(e) => {
                         if self.should_report_parse_failure(&event_id) {
@@ -278,29 +287,16 @@ impl GoogleCalendarUsageRepository {
     fn parse_event(
         &self,
         event: Event,
-        calendar_id: &str,
         resource_context: &str,
     ) -> Result<ResourceUsage, RepositoryError> {
         // Event ID から Domain ID を取得
         let event_id = event.id.clone().unwrap_or_default();
 
+        // イベントIDがそのまま予約IDになる。過去に採番した対応表がある場合のみ、
+        // 既存の予約IDを引き継ぐ（IDを変えると予約を指す既存の参照が壊れるため）。
         let domain_id = match self.id_mapper.get_domain_id(&event_id)? {
             Some(existing_domain_id) => existing_domain_id,
-            None => {
-                // マッピングが見つからない場合、新しいdomain_idを生成してマッピングを作成
-                let new_domain_id = UsageId::new();
-
-                // 新しいマッピングを保存
-                self.id_mapper.save_mapping(
-                    new_domain_id.as_str(),
-                    ExternalId {
-                        calendar_id: calendar_id.to_string(),
-                        event_id: event_id.clone(),
-                    },
-                )?;
-
-                new_domain_id.as_str().to_string()
-            }
+            None => event_id.clone(),
         };
 
         let id = UsageId::from_string(domain_id);
@@ -473,6 +469,87 @@ impl GoogleCalendarUsageRepository {
         )
     }
 
+    /// 保存対象の予約が既にカレンダー上に存在するかを調べる
+    ///
+    /// 予約IDとイベントIDは決定的に対応するため、対応表が無くてもイベントIDで確認できる。
+    /// 過去に採番した対応表がある予約はそちらを優先する。
+    async fn locate_existing_event(
+        &self,
+        usage: &ResourceUsage,
+        target_calendar_id: &str,
+    ) -> Result<Option<ExternalId>, RepositoryError> {
+        if let Some(external_id) = self.id_mapper.get_external_id(usage.id().as_str())? {
+            return Ok(Some(external_id));
+        }
+
+        let event_id = event_id_for(usage.id());
+
+        // 配置先を先に確認し、無ければ他のカレンダー（移動元）も探す
+        if self
+            .gateway
+            .get_event(target_calendar_id, &event_id)
+            .await?
+            .is_some()
+        {
+            return Ok(Some(ExternalId {
+                calendar_id: target_calendar_id.to_string(),
+                event_id,
+            }));
+        }
+
+        for (calendar_id, _resource_name) in self.calendars() {
+            if calendar_id == target_calendar_id {
+                continue;
+            }
+            if self
+                .gateway
+                .get_event(&calendar_id, &event_id)
+                .await?
+                .is_some()
+            {
+                return Ok(Some(ExternalId {
+                    calendar_id,
+                    event_id,
+                }));
+            }
+        }
+
+        Ok(None)
+    }
+
+    /// 予約を、呼び出し側が指定したIDで返す
+    ///
+    /// イベントIDと予約IDは表記が異なりうる（ハイフンの有無、過去に採番した対応表など）。
+    /// IDを指定して取得した予約は、必ずそのIDで返す必要がある。
+    fn with_id(usage: ResourceUsage, id: &UsageId) -> Result<ResourceUsage, RepositoryError> {
+        if usage.id() == id {
+            return Ok(usage);
+        }
+
+        ResourceUsage::reconstruct(
+            id.clone(),
+            usage.owner_email().clone(),
+            usage.time_period().clone(),
+            usage.resources().to_vec(),
+            usage.notes().cloned(),
+        )
+        .map_err(RepositoryError::from)
+    }
+
+    /// 予約IDから導出したイベントIDを指定して、カレンダーにイベントを作成する
+    async fn insert_event_for(
+        &self,
+        usage: &ResourceUsage,
+        calendar_id: &str,
+    ) -> Result<(), RepositoryError> {
+        let mut event = self.create_event_from_usage(usage).await?;
+        event.id = Some(event_id_for(usage.id()));
+
+        self.gateway.insert_event(calendar_id, event).await?;
+
+        Ok(())
+    }
+
     /// ResourceUsageから適切なカレンダーIDを取得
     ///
     /// # 前提条件
@@ -602,7 +679,7 @@ impl GoogleCalendarUsageRepository {
             match self.gateway.get_event(&calendar_id, event_id).await? {
                 Some(event) => {
                     // イベントをパース（この時点で新しいマッピングが作成される）
-                    let usage = self.parse_event(event, &calendar_id, &resource_context)?;
+                    let usage = self.parse_event(event, &resource_context)?;
                     return Ok(Some(usage));
                 }
                 None => {
@@ -675,8 +752,9 @@ impl ResourceUsageRepository for GoogleCalendarUsageRepository {
                         }
                     }
                     None => {
-                        // それでも見つからない場合、event_idとして全カレンダーから検索
-                        return self.find_by_event_id(input_id).await;
+                        // 対応表に無い場合、予約IDから導出したイベントIDで全カレンダーを探す
+                        let found = self.find_by_event_id(&event_id_for(id)).await?;
+                        return found.map(|usage| Self::with_id(usage, id)).transpose();
                     }
                 }
             }
@@ -695,29 +773,9 @@ impl ResourceUsageRepository for GoogleCalendarUsageRepository {
         // リソースコンテキストを取得
         let resource_context = self.get_resource_context(&external_id.calendar_id)?;
 
-        // イベントをパース（ただし、domain_idは元のinput_idを使用）
-        let mut usage = self.parse_event(event, &external_id.calendar_id, &resource_context)?;
+        let usage = self.parse_event(event, &resource_context)?;
 
-        // IMPORTANT: find_by_id() で検索した場合、取得したResourceUsageのIDは
-        // 必ず元のinput_idであるべき。parse_event()が別のdomain_idを生成した場合、
-        // それを元のinput_idで上書きする。
-        if usage.id().as_str() != input_id {
-            tracing::warn!(
-                "parse_event returned different domain_id: expected={}, got={}. Overriding with expected ID.",
-                input_id,
-                usage.id().as_str()
-            );
-            // ResourceUsageのIDを元のinput_idに置き換える
-            usage = ResourceUsage::reconstruct(
-                UsageId::from_string(input_id.to_string()),
-                usage.owner_email().clone(),
-                usage.time_period().clone(),
-                usage.resources().to_vec(),
-                usage.notes().cloned(),
-            )?;
-        }
-
-        Ok(Some(usage))
+        Ok(Some(Self::with_id(usage, id)?))
     }
 
     async fn find_future(&self) -> Result<Vec<ResourceUsage>, RepositoryError> {
@@ -764,10 +822,8 @@ impl ResourceUsageRepository for GoogleCalendarUsageRepository {
 
     async fn save(&self, usage: &ResourceUsage) -> Result<(), RepositoryError> {
         let new_calendar_id = self.get_calendar_id_for_usage(usage)?;
-        let domain_id = usage.id().as_str();
 
-        // Domain IDから外部IDを検索
-        if let Some(external_id) = self.id_mapper.get_external_id(domain_id)? {
+        if let Some(external_id) = self.locate_existing_event(usage, &new_calendar_id).await? {
             // 既存イベント
             if external_id.calendar_id == new_calendar_id {
                 // 同じカレンダー → 更新
@@ -788,11 +844,8 @@ impl ResourceUsageRepository for GoogleCalendarUsageRepository {
                         RepositoryError::ConnectionError(format!("古いイベントの削除に失敗: {}", e))
                     })?;
 
-                // 新しいカレンダーにイベントを作成
-                let event = self.create_event_from_usage(usage).await?;
-                let created_event = self
-                    .gateway
-                    .insert_event(&new_calendar_id, event)
+                // 移動先でも同じイベントIDを使うため、対応表は更新しなくてよい
+                self.insert_event_for(usage, &new_calendar_id)
                     .await
                     .map_err(|e| {
                         RepositoryError::ConnectionError(format!(
@@ -800,37 +853,10 @@ impl ResourceUsageRepository for GoogleCalendarUsageRepository {
                             e
                         ))
                     })?;
-
-                // 新しいEvent IDを取得してマッピングを更新
-                let new_event_id = created_event.id.ok_or_else(|| {
-                    RepositoryError::Unknown("作成されたイベントにIDがありません".to_string())
-                })?;
-
-                self.id_mapper.save_mapping(
-                    domain_id,
-                    ExternalId {
-                        calendar_id: new_calendar_id,
-                        event_id: new_event_id,
-                    },
-                )?;
             }
         } else {
             // 新規 → 作成
-            let event = self.create_event_from_usage(usage).await?;
-            let created_event = self.gateway.insert_event(&new_calendar_id, event).await?;
-
-            // Event IDを取得してマッピングを保存
-            let event_id = created_event.id.ok_or_else(|| {
-                RepositoryError::Unknown("作成されたイベントにIDがありません".to_string())
-            })?;
-
-            self.id_mapper.save_mapping(
-                domain_id,
-                ExternalId {
-                    calendar_id: new_calendar_id.clone(),
-                    event_id: event_id.clone(),
-                },
-            )?;
+            self.insert_event_for(usage, &new_calendar_id).await?;
         }
 
         Ok(())
@@ -855,10 +881,8 @@ impl ResourceUsageRepository for GoogleCalendarUsageRepository {
                         (ext_id, domain_id)
                     }
                     None => {
-                        // それでも見つからない場合、input_idを直接event_idとして使用
-                        // カレンダーIDを推定する必要がある
-                        // とりあえず、全カレンダーから検索して削除を試みる
-                        return self.delete_by_event_id(input_id).await;
+                        // 対応表に無い場合、予約IDから導出したイベントIDで全カレンダーを探す
+                        return self.delete_by_event_id(&event_id_for(id)).await;
                     }
                 }
             }

--- a/src/infrastructure/repositories/resource_usage/google_calendar/repository_tests.rs
+++ b/src/infrastructure/repositories/resource_usage/google_calendar/repository_tests.rs
@@ -38,6 +38,10 @@ struct ListQuery {
 struct FakeCalendarEventGateway {
     events: Vec<Event>,
     queries: Mutex<Vec<ListQuery>>,
+    /// insert_eventで受け取ったイベント（calendar_id, event）
+    inserted: Mutex<Vec<(String, Event)>>,
+    /// update_eventで受け取った対象（calendar_id, event_id）
+    updated: Mutex<Vec<(String, String)>>,
 }
 
 impl FakeCalendarEventGateway {
@@ -45,11 +49,21 @@ impl FakeCalendarEventGateway {
         Self {
             events,
             queries: Mutex::new(Vec::new()),
+            inserted: Mutex::new(Vec::new()),
+            updated: Mutex::new(Vec::new()),
         }
     }
 
     fn queries(&self) -> Vec<ListQuery> {
         self.queries.lock().unwrap().clone()
+    }
+
+    fn inserted(&self) -> Vec<(String, Event)> {
+        self.inserted.lock().unwrap().clone()
+    }
+
+    fn updated(&self) -> Vec<(String, String)> {
+        self.updated.lock().unwrap().clone()
     }
 }
 
@@ -95,26 +109,58 @@ impl CalendarEventGateway for FakeCalendarEventGateway {
     async fn get_event(
         &self,
         _calendar_id: &str,
-        _event_id: &str,
+        event_id: &str,
     ) -> Result<Option<Event>, RepositoryError> {
-        unimplemented!("このテストでは使用しない")
+        let inserted = self
+            .inserted
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|(_, event)| event.id.as_deref() == Some(event_id))
+            .map(|(_, event)| event.clone());
+
+        Ok(inserted.or_else(|| {
+            self.events
+                .iter()
+                .find(|event| event.id.as_deref() == Some(event_id))
+                .cloned()
+        }))
     }
 
     async fn insert_event(
         &self,
-        _calendar_id: &str,
-        _event: Event,
+        calendar_id: &str,
+        event: Event,
     ) -> Result<Event, RepositoryError> {
-        unimplemented!("このテストでは使用しない")
+        let mut created = event;
+        // 実APIはIDを指定しなければ自前で採番し、作成者を書き込んだアカウントで埋める
+        if created.id.is_none() {
+            created.id = Some("generated-by-google".to_string());
+        }
+        if created.creator.is_none() {
+            created.creator = Some(EventCreator {
+                email: Some(SERVICE_ACCOUNT_EMAIL.to_string()),
+                ..Default::default()
+            });
+        }
+        self.inserted
+            .lock()
+            .unwrap()
+            .push((calendar_id.to_string(), created.clone()));
+        Ok(created)
     }
 
     async fn update_event(
         &self,
-        _calendar_id: &str,
-        _event_id: &str,
+        calendar_id: &str,
+        event_id: &str,
         _event: Event,
     ) -> Result<(), RepositoryError> {
-        unimplemented!("このテストでは使用しない")
+        self.updated
+            .lock()
+            .unwrap()
+            .push((calendar_id.to_string(), event_id.to_string()));
+        Ok(())
     }
 
     async fn delete_event(
@@ -122,7 +168,7 @@ impl CalendarEventGateway for FakeCalendarEventGateway {
         _calendar_id: &str,
         _event_id: &str,
     ) -> Result<(), RepositoryError> {
-        unimplemented!("このテストでは使用しない")
+        Ok(())
     }
 }
 
@@ -694,5 +740,132 @@ async fn metadata_lines_are_not_mistaken_for_the_owner() {
         owner_lines,
         vec!["owner@example.com"],
         "予約者行はちょうど1行であるべき: {description}"
+    );
+}
+
+#[tokio::test]
+async fn saving_a_new_reservation_uses_an_event_id_derived_from_the_usage_id() {
+    let (repository, gateway, _mapping_path) =
+        repository_with_identities(StubIdentityLinkRepository::default());
+    let usage = gpu_usage("owner@example.com", 0);
+
+    repository.save(&usage).await.unwrap();
+
+    let inserted = gateway.inserted();
+    assert_eq!(inserted.len(), 1);
+    let event_id = inserted[0].1.id.clone().expect("イベントIDを指定するべき");
+    assert_eq!(
+        event_id,
+        usage.id().as_str().replace('-', ""),
+        "イベントIDは予約IDから導出されるべき"
+    );
+    assert!(
+        event_id
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit()),
+        "イベントIDに使える文字はbase32hexに限られる: {event_id}"
+    );
+}
+
+#[tokio::test]
+async fn a_saved_reservation_can_be_found_by_id_without_a_mapping_file() {
+    let (repository, _gateway, mapping_path) =
+        repository_with_identities(StubIdentityLinkRepository::default());
+    let usage = gpu_usage("owner@example.com", 0);
+
+    repository.save(&usage).await.unwrap();
+    let found = repository.find_by_id(usage.id()).await.unwrap();
+
+    assert!(found.is_some(), "保存した予約はIDで引けるべき");
+    assert_eq!(found.unwrap().id(), usage.id());
+    assert!(
+        !mapping_path.path().exists(),
+        "マッピングファイルを作らずに解決できるべき"
+    );
+}
+
+#[tokio::test]
+async fn reading_an_event_without_a_mapping_uses_the_event_id_as_the_reservation_id() {
+    let now = Utc::now();
+    let event = reservation_event(
+        "someeventid1234",
+        "0",
+        "owner@example.com",
+        now - Duration::hours(1),
+        now + Duration::hours(1),
+    );
+    let (repository, _gateway, mapping_path) = repository_with(vec![event]);
+
+    let period = TimePeriod::new(now - Duration::hours(1), now + Duration::hours(1)).unwrap();
+    let found = repository.find_overlapping(&period).await.unwrap();
+
+    assert_eq!(found.len(), 1);
+    assert_eq!(
+        found[0].id().as_str(),
+        "someeventid1234",
+        "イベントIDをそのまま予約IDとして扱うべき"
+    );
+    assert!(
+        !mapping_path.path().exists(),
+        "読み取りでマッピングを書き込んではいけない"
+    );
+}
+
+#[tokio::test]
+async fn reading_the_same_event_twice_yields_a_stable_reservation_id() {
+    let now = Utc::now();
+    let event = reservation_event(
+        "stableeventid99",
+        "0",
+        "owner@example.com",
+        now - Duration::hours(1),
+        now + Duration::hours(1),
+    );
+    let (repository, _gateway, _mapping_path) = repository_with(vec![event]);
+    let period = TimePeriod::new(now - Duration::hours(1), now + Duration::hours(1)).unwrap();
+
+    let first = repository.find_overlapping(&period).await.unwrap();
+    let second = repository.find_overlapping(&period).await.unwrap();
+
+    assert_eq!(
+        first[0].id(),
+        second[0].id(),
+        "同じイベントを読むたびにIDが変わってはいけない"
+    );
+}
+
+#[tokio::test]
+async fn updating_a_saved_reservation_updates_the_event_instead_of_inserting_again() {
+    let (repository, gateway, _mapping_path) =
+        repository_with_identities(StubIdentityLinkRepository::default());
+    let usage = gpu_usage("owner@example.com", 0);
+    repository.save(&usage).await.unwrap();
+
+    // 期間を変えて同じ予約を保存し直す
+    let extended = ResourceUsage::reconstruct(
+        usage.id().clone(),
+        usage.owner_email().clone(),
+        TimePeriod::new(
+            usage.time_period().start(),
+            usage.time_period().start() + Duration::hours(6),
+        )
+        .unwrap(),
+        usage.resources().to_vec(),
+        usage.notes().cloned(),
+    )
+    .unwrap();
+    repository.save(&extended).await.unwrap();
+
+    assert_eq!(
+        gateway.inserted().len(),
+        1,
+        "既存の予約を作り直してはいけない（同じIDのイベント作成はAPIが拒否する）"
+    );
+    let updated = gateway.updated();
+    assert_eq!(updated.len(), 1, "更新として扱うべき");
+    assert_eq!(
+        updated[0].1,
+        usage.id().as_str().replace('-', ""),
+        "同じイベントIDを更新するべき"
     );
 }


### PR DESCRIPTION
## Why

`google_calendar_mappings.json` held 526 entries mapping reservation id ↔ event id, and maintaining it caused three separate problems:

- **Reads had a write side effect.** `parse_event` allocated a fresh id and persisted a mapping whenever it met an event it had not seen. A read path writing to disk is unhealthy on its own, and a parse that failed later left the mapping behind — likely a share of those 526 entries.
- **Orphans accumulated.** Deleting an event from the calendar by hand left its mapping in place forever.
- **Ids were only stable because of the file.** Losing it meant every existing reservation silently got a new id.

None of this was necessary. Google Calendar lets the client specify `Event.id` on insert:

> Opaque identifier of the event. When creating new single or recurring events, you can specify their IDs. Provided IDs must follow these rules: characters allowed in the ID are those used in base32hex encoding, i.e. lowercase letters a-v and digits 0-9 […] the length of the ID must be between 5 and 1024 characters

A reservation id is a UUID, and its hex form (`0-9a-f`, hyphens removed, 32 chars) satisfies that rule exactly. The two can be derived from each other.

## What

- `event_id_for(usage_id)` derives the event id by dropping hyphens. `save` passes it on insert.
- `parse_event` **uses the event id as the reservation id** and writes nothing. An existing mapping still wins, so ids of reservations created before this change do not move.
- `locate_existing_event` decides insert vs. update by asking the calendar for the derived id, instead of consulting the lookup table. Without this, saving an existing reservation would have inserted a duplicate id and the API would have rejected it with a 409 — a test covers exactly that.
- `with_id` centralises "a reservation fetched by id must come back with that id", which was previously inline in one of the two lookup paths and missing from the other.
- `IdMapper::save_mapping` is gone. The file is read-only now.

## What this does *not* do

The mapping file is still read (and `delete_mapping` still prunes it on cancellation), because reservations created before this change have Google-assigned event ids that cannot be derived from their UUIDs. Those entries drain naturally as old reservations end. Deleting the file today would renumber them, so it stays.

`find_by_id` for a reservation without a mapping may probe several calendars (`get_event` per calendar, 4 configured). Acceptable for a by-id lookup, and it replaces a file read that could be stale.

## Test plan

Four tests written to fail first:

- [x] `saving_a_new_reservation_uses_an_event_id_derived_from_the_usage_id` — also asserts the id only uses base32hex characters
- [x] `a_saved_reservation_can_be_found_by_id_without_a_mapping_file` — asserts the mapping file is never created
- [x] `reading_an_event_without_a_mapping_uses_the_event_id_as_the_reservation_id` — asserts no write happens during a read
- [x] `updating_a_saved_reservation_updates_the_event_instead_of_inserting_again` — caught the 409 bug above (insert was called twice)

Plus `reading_the_same_event_twice_yields_a_stable_reservation_id` as a regression guard.

The fake gateway now models the real API more closely: it records inserts/updates, serves `get_event`, assigns an id when none is given, and fills in `creator` with the writing account — the last one was missing and initially made a passing test look like a production bug.

- [x] `cargo test --workspace --all-features` — 124 passed
- [x] `cargo clippy --workspace --all-targets --all-features -- -Dwarnings` — clean
- [x] `cargo build --workspace --all-targets --all-features` with `RUSTFLAGS=-D warnings` — clean
- [x] `cargo fmt --all --check`
- [ ] Not exercised against the live calendar. The first save after deploying will be the real check — worth watching the log for a 409 on the next reservation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KHaZgaoJcQjDGXZF9PJ9S
