### PR TITLE
fix: decide identity equality by system and user id only

### DIFF
--- a/src/application/usecases/reconcile_observed_usages.rs
+++ b/src/application/usecases/reconcile_observed_usages.rs
@@ -1,5 +1,5 @@
 use crate::application::error::ApplicationError;
-use crate::domain::aggregates::identity_link::value_objects::ExternalSystem;
+use crate::domain::aggregates::identity_link::value_objects::ExternalIdentity;
 use crate::domain::aggregates::resource_usage::entity::ResourceUsage;
 use crate::domain::aggregates::resource_usage::value_objects::Resource;
 use crate::domain::common::EmailAddress;
@@ -19,14 +19,8 @@ use tracing::{error, info};
 /// この幅に収まるものはひとつの機会としてまとめて提案する。
 const SESSION_GROUPING_WINDOW: Duration = Duration::minutes(5);
 
-/// 利用者を識別するキー（外部システムの種類＋ユーザーID）
-///
-/// `ExternalIdentity`は紐付け日時を同一性に含むため、観測ごとに生成された値どうしでは
-/// 同じ利用者と判定できない。利用者の同一判定にはこのキーを使う。
-type UserKey = (ExternalSystem, String);
-
 /// 提案済みの機会を表すキー（利用者・正規化したリソース名・開始時刻）
-type ProposedSessionKey = (UserKey, Vec<String>, DateTime<Utc>);
+type ProposedSessionKey = (ExternalIdentity, Vec<String>, DateTime<Utc>);
 
 /// 実サーバーの利用状況と予約を突き合わせ、未予約利用の提案・無断使用の通知を行うユースケース
 ///
@@ -144,10 +138,10 @@ where
     /// 利用者ごとに時刻順へ並べ、隣接する観測が`SESSION_GROUPING_WINDOW`以内であれば
     /// 同じ機会とみなす。
     fn group_into_sessions(unreserved: Vec<ObservedUsage>) -> Vec<Vec<ObservedUsage>> {
-        let mut by_user: HashMap<UserKey, Vec<ObservedUsage>> = HashMap::new();
+        let mut by_user: HashMap<ExternalIdentity, Vec<ObservedUsage>> = HashMap::new();
         for usage in unreserved {
             by_user
-                .entry(Self::user_key(&usage))
+                .entry(usage.external_identity().clone())
                 .or_default()
                 .push(usage);
         }
@@ -278,14 +272,10 @@ where
             .collect();
         normalized.sort();
 
-        (Self::user_key(first), normalized, first.active_since())
-    }
-
-    /// 観測結果から利用者を識別するキーを作る
-    fn user_key(observed: &ObservedUsage) -> UserKey {
         (
-            observed.external_identity().system().clone(),
-            observed.external_identity().user_id().to_string(),
+            first.external_identity().clone(),
+            normalized,
+            first.active_since(),
         )
     }
 

--- a/src/domain/aggregates/identity_link/entity.rs
+++ b/src/domain/aggregates/identity_link/entity.rs
@@ -1,5 +1,5 @@
 use super::errors::IdentityLinkError;
-use super::value_objects::{ExternalIdentity, ExternalSystem};
+use super::value_objects::{ExternalIdentity, ExternalIdentityBindingRecord, ExternalSystem};
 use crate::domain::common::EmailAddress;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -15,8 +15,8 @@ use serde::{Deserialize, Serialize};
 pub struct IdentityLink {
     /// 主識別子（このシステム内での一意なユーザー識別子）
     email: EmailAddress,
-    /// 外部システムでの識別情報
-    external_identities: Vec<ExternalIdentity>,
+    /// 結びつけの記録
+    external_identities: Vec<ExternalIdentityBindingRecord>,
     created_at: DateTime<Utc>,
     updated_at: DateTime<Utc>,
 }
@@ -38,7 +38,7 @@ impl IdentityLink {
         let now = Utc::now();
         Self {
             email,
-            external_identities: vec![identity],
+            external_identities: vec![ExternalIdentityBindingRecord::new(identity)],
             created_at: now,
             updated_at: now,
         }
@@ -50,7 +50,7 @@ impl IdentityLink {
     /// ビジネスロジックは適用されない（時刻は指定された値がそのまま使われる）。
     pub(crate) fn reconstitute(
         email: EmailAddress,
-        external_identities: Vec<ExternalIdentity>,
+        external_identities: Vec<ExternalIdentityBindingRecord>,
         created_at: DateTime<Utc>,
         updated_at: DateTime<Utc>,
     ) -> Self {
@@ -73,7 +73,8 @@ impl IdentityLink {
             });
         }
 
-        self.external_identities.push(identity);
+        self.external_identities
+            .push(ExternalIdentityBindingRecord::new(identity));
         self.updated_at = Utc::now();
         Ok(())
     }
@@ -84,7 +85,8 @@ impl IdentityLink {
         system: &ExternalSystem,
     ) -> Result<(), IdentityLinkError> {
         let initial_len = self.external_identities.len();
-        self.external_identities.retain(|id| id.system() != system);
+        self.external_identities
+            .retain(|record| record.identity().system() != system);
 
         if self.external_identities.len() == initial_len {
             return Err(IdentityLinkError::IdentityNotFound {
@@ -100,14 +102,15 @@ impl IdentityLink {
     pub fn get_identity_for_system(&self, system: &ExternalSystem) -> Option<&ExternalIdentity> {
         self.external_identities
             .iter()
-            .find(|id| id.system() == system)
+            .map(ExternalIdentityBindingRecord::identity)
+            .find(|identity| identity.system() == system)
     }
 
     /// 特定の外部システムと紐付けられているか
     pub fn has_identity_for_system(&self, system: &ExternalSystem) -> bool {
         self.external_identities
             .iter()
-            .any(|id| id.system() == system)
+            .any(|record| record.identity().system() == system)
     }
 
     /// いずれかの外部システムと紐付けられているか
@@ -120,8 +123,8 @@ impl IdentityLink {
         &self.email
     }
 
-    /// 外部システムの識別情報リストを取得
-    pub fn external_identities(&self) -> &[ExternalIdentity] {
+    /// 結びつけの記録を取得
+    pub fn binding_records(&self) -> &[ExternalIdentityBindingRecord] {
         &self.external_identities
     }
 
@@ -147,7 +150,7 @@ mod tests {
 
         assert_eq!(identity.email(), &email);
         assert!(!identity.is_linked_to_any_system());
-        assert_eq!(identity.external_identities().len(), 0);
+        assert_eq!(identity.binding_records().len(), 0);
     }
 
     #[test]

--- a/src/domain/aggregates/identity_link/value_objects/binding_record.rs
+++ b/src/domain/aggregates/identity_link/value_objects/binding_record.rs
@@ -1,0 +1,76 @@
+use super::ExternalIdentity;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// 識別子を結びつけた記録
+///
+/// 識別子そのもの（どのシステムの、どの名前か）と、それを結びつけた出来事
+/// （いつ結びつけたか）は別の関心である。両者を1つの値にまとめると、同じメンバーを
+/// 指す識別子が、結びつけた時刻が違うだけで別物として扱われてしまう。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExternalIdentityBindingRecord {
+    /// 結びつけた識別子
+    identity: ExternalIdentity,
+    /// 結びつけた日時
+    linked_at: DateTime<Utc>,
+}
+
+impl ExternalIdentityBindingRecord {
+    /// 識別子を今結びつけた記録を作る
+    pub fn new(identity: ExternalIdentity) -> Self {
+        Self {
+            identity,
+            linked_at: Utc::now(),
+        }
+    }
+
+    /// 永続化層からの復元用
+    pub(crate) fn reconstitute(identity: ExternalIdentity, linked_at: DateTime<Utc>) -> Self {
+        Self {
+            identity,
+            linked_at,
+        }
+    }
+
+    /// 結びつけた識別子を取得
+    pub fn identity(&self) -> &ExternalIdentity {
+        &self.identity
+    }
+
+    /// 結びつけた日時を取得
+    pub fn linked_at(&self) -> DateTime<Utc> {
+        self.linked_at
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::aggregates::identity_link::value_objects::ExternalSystem;
+
+    fn os_identity() -> ExternalIdentity {
+        ExternalIdentity::new(
+            ExternalSystem::Os {
+                server: "Thalys".to_string(),
+            },
+            "kkawaguchi".to_string(),
+        )
+    }
+
+    #[test]
+    fn records_differ_when_the_binding_time_differs() {
+        // 記録としては、いつ結びつけたかまで含めて同じであるときに同じ
+        let earlier = ExternalIdentityBindingRecord::reconstitute(
+            os_identity(),
+            Utc::now() - chrono::Duration::days(30),
+        );
+        let later = ExternalIdentityBindingRecord::reconstitute(os_identity(), Utc::now());
+
+        assert_ne!(earlier, later);
+        assert_eq!(
+            earlier.identity(),
+            later.identity(),
+            "結びつけた識別子そのものは同じ"
+        );
+    }
+}

--- a/src/domain/aggregates/identity_link/value_objects/external_identity.rs
+++ b/src/domain/aggregates/identity_link/value_objects/external_identity.rs
@@ -1,16 +1,16 @@
 use super::ExternalSystem;
-use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-/// 外部システムでのユーザー識別情報
+/// あるシステムにおけるメンバーの識別子
+///
+/// 「どのシステムの、どの名前か」で決まる。いつ結びつけたかは識別子そのものの性質では
+/// ないため、`ExternalIdentityBindingRecord`が持つ。
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ExternalIdentity {
-    /// 外部システムの種類
+    /// システムの種類
     system: ExternalSystem,
-    /// 外部システムでのユーザーID
+    /// そのシステムでのユーザーID
     user_id: String,
-    /// 紐付けた日時
-    linked_at: DateTime<Utc>,
 }
 
 impl ExternalIdentity {
@@ -20,24 +20,7 @@ impl ExternalIdentity {
     /// * `system` - 外部システムの種類
     /// * `user_id` - 外部システムでのユーザーID
     pub fn new(system: ExternalSystem, user_id: String) -> Self {
-        Self {
-            system,
-            user_id,
-            linked_at: Utc::now(),
-        }
-    }
-
-    /// 永続化層からの復元用
-    pub(crate) fn reconstitute(
-        system: ExternalSystem,
-        user_id: String,
-        linked_at: DateTime<Utc>,
-    ) -> Self {
-        Self {
-            system,
-            user_id,
-            linked_at,
-        }
+        Self { system, user_id }
     }
 
     /// 外部システムの種類を取得
@@ -45,13 +28,61 @@ impl ExternalIdentity {
         &self.system
     }
 
-    /// 外部システムでのユーザーIDを取得
+    /// そのシステムでのユーザーIDを取得
     pub fn user_id(&self) -> &str {
         &self.user_id
     }
+}
 
-    /// 紐付けた日時を取得
-    pub fn linked_at(&self) -> DateTime<Utc> {
-        self.linked_at
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    fn os_system() -> ExternalSystem {
+        ExternalSystem::Os {
+            server: "Thalys".to_string(),
+        }
+    }
+
+    #[test]
+    fn the_same_user_on_the_same_system_is_the_same_identity() {
+        let a = ExternalIdentity::new(os_system(), "kkawaguchi".to_string());
+        let b = ExternalIdentity::new(os_system(), "kkawaguchi".to_string());
+
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn identities_can_be_used_as_a_map_key() {
+        let mut set = HashSet::new();
+        set.insert(ExternalIdentity::new(os_system(), "kkawaguchi".to_string()));
+        set.insert(ExternalIdentity::new(os_system(), "kkawaguchi".to_string()));
+
+        assert_eq!(set.len(), 1, "同じ利用者を表す値はキーとして一致するべき");
+    }
+
+    #[test]
+    fn the_os_namespace_is_per_server() {
+        let on_thalys = ExternalIdentity::new(os_system(), "kkawaguchi".to_string());
+        let on_freccia = ExternalIdentity::new(
+            ExternalSystem::Os {
+                server: "Freccia".to_string(),
+            },
+            "kkawaguchi".to_string(),
+        );
+
+        assert_ne!(
+            on_thalys, on_freccia,
+            "OSユーザー名の名前空間はサーバーごとに独立している"
+        );
+    }
+
+    #[test]
+    fn different_systems_are_different_identities() {
+        let os = ExternalIdentity::new(os_system(), "kkawaguchi".to_string());
+        let slack = ExternalIdentity::new(ExternalSystem::Slack, "kkawaguchi".to_string());
+
+        assert_ne!(os, slack);
     }
 }

--- a/src/domain/aggregates/identity_link/value_objects/mod.rs
+++ b/src/domain/aggregates/identity_link/value_objects/mod.rs
@@ -1,5 +1,7 @@
+mod binding_record;
 mod external_identity;
 mod external_system;
 
+pub use binding_record::ExternalIdentityBindingRecord;
 pub use external_identity::ExternalIdentity;
 pub use external_system::ExternalSystem;

--- a/src/infrastructure/repositories/identity_link/json_file.rs
+++ b/src/infrastructure/repositories/identity_link/json_file.rs
@@ -1,6 +1,6 @@
 use crate::domain::aggregates::identity_link::{
     entity::IdentityLink,
-    value_objects::{ExternalIdentity, ExternalSystem},
+    value_objects::{ExternalIdentity, ExternalIdentityBindingRecord, ExternalSystem},
 };
 use crate::domain::common::EmailAddress;
 use crate::domain::ports::repositories::{IdentityLinkRepository, RepositoryError};
@@ -53,12 +53,12 @@ struct ExternalIdentityDto {
 impl IdentityLinkDto {
     fn from_entity(entity: &IdentityLink) -> Self {
         let external_identities = entity
-            .external_identities()
+            .binding_records()
             .iter()
-            .map(|id| ExternalIdentityDto {
-                system: id.system().as_str(),
-                user_id: id.user_id().to_string(),
-                linked_at: id.linked_at(),
+            .map(|record| ExternalIdentityDto {
+                system: record.identity().system().as_str(),
+                user_id: record.identity().user_id().to_string(),
+                linked_at: record.linked_at(),
             })
             .collect();
 
@@ -73,13 +73,16 @@ impl IdentityLinkDto {
     fn to_entity(&self) -> Result<IdentityLink, RepositoryError> {
         let email = EmailAddress::new(self.email.clone())?;
 
-        let external_identities: Vec<ExternalIdentity> = self
+        let external_identities: Vec<ExternalIdentityBindingRecord> = self
             .external_identities
             .iter()
             .filter_map(|dto| {
                 // 現在サポートしているシステムのみ復元
                 ExternalSystem::from_str(&dto.system).ok().map(|system| {
-                    ExternalIdentity::reconstitute(system, dto.user_id.clone(), dto.linked_at)
+                    ExternalIdentityBindingRecord::reconstitute(
+                        ExternalIdentity::new(system, dto.user_id.clone()),
+                        dto.linked_at,
+                    )
                 })
             })
             .collect();
@@ -208,5 +211,79 @@ impl IdentityLinkRepository for JsonFileIdentityLinkRepository {
         self.save_to_file().await?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// 運用中の identity_links.json に保存されている形
+    const PERSISTED: &str = r#"{
+      "email": "member@example.com",
+      "external_identities": [
+        {"system": "slack", "user_id": "U01ABCDEF", "linked_at": "2025-11-12T07:05:35Z"},
+        {"system": "os:Thalys", "user_id": "kkawaguchi", "linked_at": "2026-07-24T14:06:14Z"}
+      ],
+      "created_at": "2025-11-12T07:05:35Z",
+      "updated_at": "2025-11-12T07:05:35Z"
+    }"#;
+
+    #[test]
+    fn reads_the_identity_links_written_by_earlier_versions() {
+        let dto: IdentityLinkDto = serde_json::from_str(PERSISTED).unwrap();
+        let entity = dto.to_entity().unwrap();
+
+        assert_eq!(entity.email().as_str(), "member@example.com");
+
+        let slack = entity
+            .get_identity_for_system(&ExternalSystem::Slack)
+            .expect("Slackの識別子が読めるべき");
+        assert_eq!(slack.user_id(), "U01ABCDEF");
+
+        let os = entity
+            .get_identity_for_system(&ExternalSystem::Os {
+                server: "Thalys".to_string(),
+            })
+            .expect("サーバーごとの識別子が読めるべき");
+        assert_eq!(os.user_id(), "kkawaguchi");
+    }
+
+    #[test]
+    fn keeps_the_binding_time_through_a_round_trip() {
+        let dto: IdentityLinkDto = serde_json::from_str(PERSISTED).unwrap();
+        let entity = dto.to_entity().unwrap();
+
+        let written = serde_json::to_string(&IdentityLinkDto::from_entity(&entity)).unwrap();
+
+        assert!(
+            written.contains(r#""system":"os:Thalys""#),
+            "システムの表記を変えてはいけない: {written}"
+        );
+        assert!(
+            written.contains("2026-07-24T14:06:14Z"),
+            "結びつけた日時を失ってはいけない: {written}"
+        );
+    }
+
+    #[test]
+    fn skips_identities_for_systems_that_are_no_longer_supported() {
+        let json = r#"{
+          "email": "member@example.com",
+          "external_identities": [
+            {"system": "discord", "user_id": "x", "linked_at": "2025-11-12T07:05:35Z"},
+            {"system": "slack", "user_id": "U01ABCDEF", "linked_at": "2025-11-12T07:05:35Z"}
+          ],
+          "created_at": "2025-11-12T07:05:35Z",
+          "updated_at": "2025-11-12T07:05:35Z"
+        }"#;
+
+        let entity = serde_json::from_str::<IdentityLinkDto>(json)
+            .unwrap()
+            .to_entity()
+            .unwrap();
+
+        assert_eq!(entity.binding_records().len(), 1);
+        assert!(entity.has_identity_for_system(&ExternalSystem::Slack));
     }
 }


### PR DESCRIPTION
## Why

`ExternalIdentity` held `linked_at`, so two values describing **the same member on the same system** compared as different whenever they were linked at different moments. Using one as a `HashMap`/`HashSet` key silently split a single member into several.

This was hit for real. The proposal grouping in #104 keys observations by member, and with `ExternalIdentity` as the key every GPU became its own group — three cards instead of one. It shipped with a hand-built `(ExternalSystem, String)` tuple as a workaround.

The workaround was the wrong response. A value object's identity is decided by **every** attribute it holds; writing `PartialEq` by hand to exclude one attribute is a way of saying that attribute does not belong to the value. That is a design signal, not something to route around.

## What

Split the two concerns that were living in one type.

```rust
/// あるシステムにおけるメンバーの識別子
struct ExternalIdentity { system: ExternalSystem, user_id: String }

/// 識別子を結びつけた記録
struct ExternalIdentityBindingRecord { identity: ExternalIdentity, linked_at: DateTime<Utc> }
```

Both derive `PartialEq`/`Hash` over all of their fields, so the principle holds in both places. `IdentityLink` now holds binding records; `get_identity_for_system` still returns an `&ExternalIdentity`.

The grouping workaround is removed — `ExternalIdentity` is a usable key now.

## Why `linked_at` was kept rather than deleted

It is read nowhere except the persistence round trip, so deleting it was on the table. It stays because the information is not recoverable once dropped, and there is a plausible use:

> When a member graduates, the same OS login name can later be assigned to someone else. Knowing when an identifier started belonging to a person tells you whose records the older entries are.

Login name reuse is realistic on a shared lab server, so this is not a hypothetical.

## Not a breaking change

The crate is not published, so there are no external consumers of `PartialEq`. The persisted shape of `identity_links.json` is unchanged: the DTO layer converts `ExternalSystem` to `"os:Thalys"` style strings, and it was never derived serde in the first place. Real data (20 links, 80 identities) contains no `(system, user_id)` duplicates, so nothing collapses on load.

Naming: "External" is a system-side word — nobody says "外部システムの識別情報", they say "Slack のアカウント" or "Thalys のログイン名". Renaming is a separate concern and not touched here.

## Test plan

Two tests confirmed failing first (`the_same_user_on_the_same_system_is_the_same_identity`, `identities_can_be_used_as_a_map_key`).

- [x] `ExternalIdentity`: equality, usability as a map key, per-server OS namespaces, different systems
- [x] `ExternalIdentityBindingRecord`: records with different binding times differ, while the identity inside them is the same
- [x] `JsonFileIdentityLinkRepository`: reads a document written by earlier versions, preserves `"os:Thalys"` and the binding time through a round trip, skips identities for unsupported systems — this layer had **no tests at all** before, which is why the persisted format had nothing guarding it
- [x] `cargo test --workspace --all-features` — 127 passed
- [x] `cargo clippy --workspace --all-targets --all-features -- -Dwarnings` — clean
- [x] `cargo build --workspace --all-targets --all-features` with `RUSTFLAGS=-D warnings` — clean
- [x] `cargo fmt --all --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KHaZgaoJcQjDGXZF9PJ9S
