### PR TITLE
docs: replace deployment-specific examples with generic ones

### DIFF
--- a/config/resources.toml.example
+++ b/config/resources.toml.example
@@ -2,8 +2,8 @@
 # このファイルをコピーして config/resources.toml として使用してください
 
 [[servers]]
-name = "Name1"
-calendar_id = "hoge@group.calendar.google.com"
+name = "gpu-server-1"
+calendar_id = "your-calendar-id@group.calendar.google.com"
 
 # 通知設定(複数設定可能)
 [[servers.notifications]]
@@ -28,9 +28,9 @@ channel_id = "C01234567..."
 # フォーマット設定（オプション）
 # [servers.notifications.format]
 # resource_style = "full"    # "full" | "compact" | "server_only"
-#   - full: "Thalys / A100 80GB PCIe / GPU:0"
-#   - compact: "Thalys 0,1,2"
-#   - server_only: "Thalys"
+#   - full: "gpu-server-1 / A100 80GB PCIe / GPU:0"
+#   - compact: "gpu-server-1 0,1,2"
+#   - server_only: "gpu-server-1"
 # time_style = "full"        # "full" | "smart" | "relative"
 #   - full: "2024-01-15 19:00 - 2024-01-15 21:00 (Asia/Tokyo)"
 #   - smart: "1/15 19:00 - 21:00" (同日なら終了日省略)
@@ -47,17 +47,17 @@ channel_id = "C01234567..."
 
 [[servers.devices]]
 id = 0
-model = "RTX PRO 6000 Blackwell Max-Q"
+model = "A100 80GB PCIe"
 
 [[servers.devices]]
 id = 1
-model = "RTX PRO 6000 Blackwell Max-Q"
+model = "A100 80GB PCIe"
 
 # ---
 
 [[servers]]
-name = "Name2"
-calendar_id = "hoge@group.calendar.google.com"
+name = "gpu-server-2"
+calendar_id = "your-calendar-id@group.calendar.google.com"
 
 [[servers.notifications]]
 type = "slack"
@@ -75,8 +75,8 @@ model = "A100 80GB PCIe"
 # ---
 
 [[rooms]]
-name = "部屋1"
-calendar_id = "hoge@group.calendar.google.com"
+name = "Meeting Room A"
+calendar_id = "your-calendar-id@group.calendar.google.com"
 
 [[rooms.notifications]]
 type = "slack"

--- a/docs/ADMIN_GUIDE.md
+++ b/docs/ADMIN_GUIDE.md
@@ -47,7 +47,7 @@ Define GPU servers and rooms in `config/resources.toml`:
 
 ```toml
 [[servers]]
-name = "Thalys"
+name = "gpu-server-1"
 calendar_id = "your-calendar-id@group.calendar.google.com"  # Repository implementation-specific ID
 
 # Configure notification destinations per resource
@@ -147,9 +147,9 @@ conflict is silently dropped.
 
 | Value | Example Output |
 |-------|----------------|
-| `full` (default) | Thalys / A100 80GB PCIe / GPU:0 |
-| `compact` | Thalys 0,1,2 |
-| `server_only` | Thalys |
+| `full` (default) | gpu-server-1 / A100 80GB PCIe / GPU:0 |
+| `compact` | gpu-server-1 0,1,2 |
+| `server_only` | gpu-server-1 |
 
 **time_style options:**
 
@@ -186,7 +186,7 @@ binary as a cron job on each GPU server. This binary ships alongside the main
 
 **Prerequisites:**
 
-- A shared directory (e.g., NFS) readable/writable from every monitored server (e.g., Thalys, Freccia, Lyria)
+- A shared directory (e.g., NFS) readable/writable from every monitored server
 - `nvidia-smi`, `getconf`, and `getent` available on each server (all standard on typical
   Linux setups). `gpu-usage-reporter` itself is a musl static build with no other runtime
   dependencies.
@@ -194,24 +194,20 @@ binary as a cron job on each GPU server. This binary ships alongside the main
 **Setup steps:**
 
 This binary is the "reporting side" of the setup. Deploy it to **every monitored server
-individually** — not just the one running the LRM binary (e.g., Thalys) — including
-Freccia and Lyria, each with its own `--server-name`.
+individually**, including the one that runs the LRM binary itself, each with its own
+`--server-name`.
 
 1. Deploy `gpu-usage-reporter` to every monitored server.
 2. Register it in each server's crontab, using that server's own name (example: every minute):
 
    ```cron
-   # crontab on Thalys
+   # crontab on gpu-server-1
    * * * * * /usr/local/bin/gpu-usage-reporter \
-       --server-name Thalys --output-dir /mnt/shared/lrm-gpu-status
+       --server-name gpu-server-1 --output-dir /mnt/shared/lrm-gpu-status
 
-   # crontab on Freccia
+   # crontab on gpu-server-2
    * * * * * /usr/local/bin/gpu-usage-reporter \
-       --server-name Freccia --output-dir /mnt/shared/lrm-gpu-status
-
-   # crontab on Lyria
-   * * * * * /usr/local/bin/gpu-usage-reporter \
-       --server-name Lyria --output-dir /mnt/shared/lrm-gpu-status
+       --server-name gpu-server-2 --output-dir /mnt/shared/lrm-gpu-status
    ```
 
    `--output-dir` must point to the same shared directory from every server (see
@@ -223,10 +219,10 @@ Freccia and Lyria, each with its own `--server-name`.
 
 ```json
 {
-  "server": "Thalys",
+  "server": "gpu-server-1",
   "generated_at": "2026-07-24T12:00:00+00:00",
   "processes": [
-    {"device_number": 0, "os_user": "kkawaguchi", "started_at": "2026-07-24T10:00:00+00:00"}
+    {"device_number": 0, "os_user": "alice", "started_at": "2026-07-24T10:00:00+00:00"}
   ]
 }
 ```

--- a/docs/ADMIN_GUIDE_ja.md
+++ b/docs/ADMIN_GUIDE_ja.md
@@ -47,7 +47,7 @@ Google Calendarリポジトリを使用する場合:
 
 ```toml
 [[servers]]
-name = "Thalys"
+name = "gpu-server-1"
 calendar_id = "your-calendar-id@group.calendar.google.com"  # リポジトリ実装固有のID
 
 # リソースごとに通知先を設定
@@ -143,9 +143,9 @@ date_format = "md"           # 日付フォーマット
 
 | 値 | 出力例 |
 |----|--------|
-| `full`（デフォルト） | Thalys / A100 80GB PCIe / GPU:0 |
-| `compact` | Thalys 0,1,2 |
-| `server_only` | Thalys |
+| `full`（デフォルト） | gpu-server-1 / A100 80GB PCIe / GPU:0 |
+| `compact` | gpu-server-1 0,1,2 |
+| `server_only` | gpu-server-1 |
 
 **time_style オプション:**
 
@@ -181,31 +181,27 @@ cron登録する必要があります。このバイナリはリリースアー�
 
 **前提条件:**
 
-- 監視対象の全サーバー（例: Thalys, Freccia, Lyria）から読み書きできる共有ディレクトリ（NFS等）
+- 監視対象の全サーバーから読み書きできる共有ディレクトリ（NFS等）
 - 各サーバーに`nvidia-smi`・`getconf`・`getent`（いずれも標準的なLinux環境に含まれる）があること。
   `gpu-usage-reporter`自体はmuslスタティックビルドのため、これ以外の実行時依存はない
 
 **セットアップ手順:**
 
-このバイナリは「送り出す側」の設定です。LRM本体が動くサーバー（例: Thalys）だけでなく、
-**監視対象の全サーバー（Thalys・Freccia・Lyriaそれぞれ）に個別にデプロイ**し、
+このバイナリは「送り出す側」の設定です。LRM本体が動くサーバー自身も含め、
+**監視対象の全サーバーに個別にデプロイ**し、
 各サーバー自身の`--server-name`を指定してcron登録してください。
 
 1. `gpu-usage-reporter`を監視対象の全サーバーに配置する
 2. 各サーバーのcrontabに、そのサーバー自身の名前で登録する（1分間隔の例）:
 
    ```cron
-   # Thalys側のcrontab
+   # gpu-server-1側のcrontab
    * * * * * /usr/local/bin/gpu-usage-reporter \
-       --server-name Thalys --output-dir /mnt/shared/lrm-gpu-status
+       --server-name gpu-server-1 --output-dir /mnt/shared/lrm-gpu-status
 
-   # Freccia側のcrontab
+   # gpu-server-2側のcrontab
    * * * * * /usr/local/bin/gpu-usage-reporter \
-       --server-name Freccia --output-dir /mnt/shared/lrm-gpu-status
-
-   # Lyria側のcrontab
-   * * * * * /usr/local/bin/gpu-usage-reporter \
-       --server-name Lyria --output-dir /mnt/shared/lrm-gpu-status
+       --server-name gpu-server-2 --output-dir /mnt/shared/lrm-gpu-status
    ```
 
    `--output-dir`はどのサーバーからも同じ共有ディレクトリを指す必要があります（前提条件参照）。
@@ -217,10 +213,10 @@ cron登録する必要があります。このバイナリはリリースアー�
 
 ```json
 {
-  "server": "Thalys",
+  "server": "gpu-server-1",
   "generated_at": "2026-07-24T12:00:00+00:00",
   "processes": [
-    {"device_number": 0, "os_user": "kkawaguchi", "started_at": "2026-07-24T10:00:00+00:00"}
+    {"device_number": 0, "os_user": "alice", "started_at": "2026-07-24T10:00:00+00:00"}
   ]
 }
 ```

--- a/src/infrastructure/config/resource_config.rs
+++ b/src/infrastructure/config/resource_config.rs
@@ -66,6 +66,10 @@ impl NotificationConfig {
 }
 
 /// リソース全体の設定
+///
+/// TODO(#113): 保存先の指定をリソース定義から分離する。この設定はSlackのビューやMCPなど
+/// 「何が予約できるか」を知りたいだけの箇所にも渡るため、永続化実装の識別子が
+/// 不要な範囲まで届いている
 #[derive(Debug, Deserialize, Clone)]
 pub struct ResourceConfig {
     /// サーバー（GPU）の設定リスト
@@ -79,7 +83,7 @@ pub struct ResourceConfig {
 pub struct ServerConfig {
     /// サーバー名
     pub name: String,
-    /// カレンダーID
+    /// カレンダーID（Google Calendar実装固有。TODO(#113)を参照）
     pub calendar_id: String,
     /// デバイス（GPU）のリスト
     pub devices: Vec<DeviceConfig>,
@@ -101,7 +105,7 @@ pub struct DeviceConfig {
 pub struct RoomConfig {
     /// 部屋名
     pub name: String,
-    /// カレンダーID
+    /// カレンダーID（Google Calendar実装固有。TODO(#113)を参照）
     pub calendar_id: String,
     /// 通知設定のリスト
     pub notifications: Vec<NotificationConfig>,


### PR DESCRIPTION
## Why

The documentation described one particular deployment rather than the software. A reader setting this up elsewhere had to guess which parts were examples and which were requirements.

## What was wrong

**Server names were real machines.** `Thalys`, `Freccia`, `Lyria` are the hosts of the lab that wrote this. They are train names, so nothing in them says "this is a GPU server" — a reader cannot tell what they stand for.

**The reporter setup told readers to deploy to hosts that do not exist for them.**

> Deploy it to **every monitored server individually** — not just the one running the LRM binary (e.g., Thalys) — including Freccia and Lyria, each with its own `--server-name`.

The rule being described is "every monitored server, including the one running LRM". Naming two specific extra machines turns a rule into a list, and the list is wrong for everyone except us. The crontab sample listed three named hosts for the same reason.

**The example config was in worse shape than the guides**, despite being the file people copy:

| | before | guides said |
|---|---|---|
| server name | `Name1` / `Name2` | `Thalys` |
| calendar id | `hoge@group.calendar.google.com` | `your-calendar-id@group.calendar.google.com` |
| room name | `部屋1` | `Meeting Room A` |
| GPU model | `RTX PRO 6000 Blackwell Max-Q` | `A100 80GB PCIe` |

`hoge` is a Japanese-language placeholder that means nothing to an English reader, and `部屋1` left Japanese text in a file referenced from the English guide.

**A real OS user name was in the sample payload** — `"os_user": "kkawaguchi"` in the reporter's JSON schema example.

## What changed

- Server names → `gpu-server-1` / `gpu-server-2` across guides and example config
- Reporter section states the rule ("including the one that runs the LRM binary itself") instead of naming hosts; crontab sample shows two generic hosts
- Example config aligned with the guides: `your-calendar-id@...`, `Meeting Room A`, `A100 80GB PCIe`
- Sample payload uses `alice`

Both language versions updated.

## Checked and left alone

- `github.com/kano-lab/lab-resource-manager` URLs — this project's own repository, correct as-is
- `/mnt/shared/lrm-gpu-status`, `Meeting Room A`, `A100 80GB PCIe` — generic enough to serve as examples
- `README*.md`, `USER_GUIDE*.md` — already free of deployment-specific names
- No real calendar ids or tokens were present anywhere; every credential in the docs was already a placeholder

## Test plan

- [x] `grep` for `Thalys|Freccia|Lyria|kkawaguchi|hoge|部屋1|Name1|Name2` across `docs/`, `config/`, `README*.md`, `deploy/` — no matches remain (excluding the repository URL)
- [x] Names are used consistently: `gpu-server-1` ×18, `gpu-server-2` ×5, `A100 80GB PCIe` ×11, `your-calendar-id@...` ×5, `alice` ×4, `Meeting Room A` ×2
- [x] `markdownlint-cli2` over the CI's glob — 147 errors before, 147 after. All are pre-existing MD060 table-style noise; no new findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KHaZgaoJcQjDGXZF9PJ9S

---

## Second commit: marking the storage-mapping leak

While going through the example config, `calendar_id` stood out. Storage details in configuration are fine — an operator has to say where data lives. What is not fine is that it sits in the same table as the resource definitions:

```toml
[[servers]]
name = "gpu-server-1"     # what can be reserved
calendar_id = "..."       # where it is stored
```

`ResourceConfig` is handed to Slack views, the MCP server, the notification router and the conflict message builder. None of them needs a calendar id, yet all of them can see one.

The asymmetry makes it clearer: notification destinations in the same file are tagged with `type` and modelled as an enum over `slack`/`mock`, so implementation-specific settings already have a convention here. `calendar_id` has no tag and no alternative — persistence is the one thing hardwired.

Splitting it changes the config schema, so it waits for a major release. This commit only records the intent at the definitions, referencing #113.
