### PR TITLE
fix: bound how far ahead future reservations are searched

### DIFF
--- a/src/infrastructure/repositories/resource_usage/google_calendar/repository.rs
+++ b/src/infrastructure/repositories/resource_usage/google_calendar/repository.rs
@@ -12,7 +12,7 @@ use crate::domain::ports::repositories::{
 };
 use crate::infrastructure::config::ResourceConfig;
 use async_trait::async_trait;
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Duration, Utc};
 use google_calendar3::{
     CalendarHub,
     api::Event,
@@ -51,6 +51,13 @@ const RESERVATION_ID_LINE_PREFIX: &str = "予約ID: ";
 fn event_id_for(usage_id: &UsageId) -> String {
     usage_id.as_str().replace('-', "")
 }
+
+/// 「今後の予約」として扱う期間の上限
+///
+/// 繰り返し予約は個々の予定へ展開して取得するため、上限を設けないとカレンダーが
+/// 展開できる限り（数十年先まで）返ってくる。予約の閲覧・変更通知にとって遠い将来は
+/// 意味を持たないので、ここで区切る。
+const FUTURE_HORIZON: Duration = Duration::days(365);
 
 /// キャンセル済みイベントのstatus値
 const EVENT_STATUS_CANCELLED: &str = "cancelled";
@@ -782,9 +789,10 @@ impl ResourceUsageRepository for GoogleCalendarUsageRepository {
     }
 
     async fn find_future(&self) -> Result<Vec<ResourceUsage>, RepositoryError> {
-        // 終了時刻が現在より後のイベントに限る。開始時刻では絞らないため、
+        // 終了時刻が現在より後のイベントに限る。開始時刻の下限は設けないため、
         // 進行中のイベント（開始時刻が過去）も含まれる。
-        let events = self.fetch_events(Utc::now(), None).await?;
+        let now = Utc::now();
+        let events = self.fetch_events(now, Some(now + FUTURE_HORIZON)).await?;
 
         Ok(self.parse_events(events))
     }

--- a/src/infrastructure/repositories/resource_usage/google_calendar/repository_tests.rs
+++ b/src/infrastructure/repositories/resource_usage/google_calendar/repository_tests.rs
@@ -869,3 +869,46 @@ async fn updating_a_saved_reservation_updates_the_event_instead_of_inserting_aga
         "同じイベントIDを更新するべき"
     );
 }
+
+#[tokio::test]
+async fn find_future_bounds_how_far_ahead_it_looks() {
+    // 繰り返し予約は個々の予定へ展開されるため、上限を設けないとカレンダーが
+    // 展開できる限り（数十年先まで）返ってくる
+    let (repository, gateway, _mapping_path) = repository_with(vec![]);
+
+    repository.find_future().await.unwrap();
+
+    let queries = gateway.queries();
+    assert_eq!(queries.len(), 1);
+    let time_max = queries[0]
+        .time_max
+        .expect("今後の予約を探す範囲には上限が必要");
+    let horizon = time_max - queries[0].time_min;
+    assert!(
+        horizon <= Duration::days(366),
+        "上限が遠すぎる: {}日",
+        horizon.num_days()
+    );
+    assert!(
+        horizon >= Duration::days(90),
+        "上限が近すぎると先の予約が見えなくなる: {}日",
+        horizon.num_days()
+    );
+}
+
+#[tokio::test]
+async fn find_future_still_returns_a_reservation_inside_the_horizon() {
+    let now = Utc::now();
+    let soon = reservation_event(
+        "within-horizon",
+        "0",
+        "owner@example.com",
+        now + Duration::days(30),
+        now + Duration::days(30) + Duration::hours(1),
+    );
+    let (repository, _gateway, _mapping_path) = repository_with(vec![soon]);
+
+    let future = repository.find_future().await.unwrap();
+
+    assert_eq!(future.len(), 1, "上限内の予約は返るべき");
+}


### PR DESCRIPTION
## Why

v1.5.0 started expanding recurring events into individual instances (`singleEvents=true`). `find_future` has no upper bound on its search, so the calendar returns every instance it can generate.

A weekly recurring room booking — a legitimate standing meeting — expanded to **1,442 reservations reaching into 2040**:

```
2026-07-28T01:00:00Z
...
2040-06-21T07:05:00Z
```

Consequences:

- The reservation listing became unusable (356 KB / 14,484 lines from `list_all_reservations`)
- Every polling cycle walked the whole set
- Before #109 stopped reads from writing, each cycle also allocated ids for newly-seen instances: the mapping file grew from 526 to 1,981 entries (428 KB) in about 90 minutes

The recurring booking is correct data. The defect is searching without a horizon while expanding recurrences.

## What

Bound `find_future` at one year (`FUTURE_HORIZON`). Reviewing reservations and noticing changes to them does not need a longer view, and a weekly booking stays visible at 52 instances.

`find_overlapping` is unaffected — it already queries the requested interval only.

## Test plan

- [x] `find_future_bounds_how_far_ahead_it_looks` — confirmed failing first ("今後の予約を探す範囲には上限が必要"). Asserts a bound exists and is between 90 and 366 days, so the value can be tuned without rewriting the test
- [x] `find_future_still_returns_a_reservation_inside_the_horizon` — a booking 30 days out is still returned
- [x] `cargo test --workspace --all-features` — 136 passed
- [x] `cargo clippy --workspace --all-targets --all-features -- -Dwarnings` — clean
- [x] `cargo fmt --all --check`
- [ ] The mapping file still holds the ~1,450 entries allocated while the read side was writing. Harmless (read-only since #109) but worth pruning; tracked separately under #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KHaZgaoJcQjDGXZF9PJ9S