### PR TITLE
refactor: let callers state the range of reservations they need

### DIFF
--- a/src/application/usecases/accept_reservation_proposal.rs
+++ b/src/application/usecases/accept_reservation_proposal.rs
@@ -434,10 +434,6 @@ mod tests {
             Ok(self.all().into_iter().find(|usage| usage.id() == id))
         }
 
-        async fn find_future(&self) -> Result<Vec<ResourceUsage>, RepositoryError> {
-            Ok(self.visible.lock().unwrap().clone())
-        }
-
         async fn find_overlapping(
             &self,
             time_period: &TimePeriod,
@@ -455,6 +451,7 @@ mod tests {
         async fn find_by_owner(
             &self,
             owner_email: &EmailAddress,
+            time_period: &TimePeriod,
         ) -> Result<Vec<ResourceUsage>, RepositoryError> {
             Ok(self
                 .visible
@@ -462,6 +459,7 @@ mod tests {
                 .unwrap()
                 .iter()
                 .filter(|usage| usage.owner_email() == owner_email)
+                .filter(|usage| usage.time_period().overlaps_with(time_period))
                 .cloned()
                 .collect())
         }

--- a/src/application/usecases/list_all_future_resource_usages.rs
+++ b/src/application/usecases/list_all_future_resource_usages.rs
@@ -1,9 +1,10 @@
 use crate::application::error::ApplicationError;
 use crate::domain::aggregates::resource_usage::entity::ResourceUsage;
+use crate::domain::aggregates::resource_usage::value_objects::TimePeriod;
 use crate::domain::ports::repositories::ResourceUsageRepository;
 use std::sync::Arc;
 
-/// 全ての未来のリソース使用予定を取得するユースケース
+/// 指定期間のリソース使用予定を一覧するユースケース
 pub struct ListAllFutureResourceUsagesUseCase<R: ResourceUsageRepository> {
     repository: Arc<R>,
 }
@@ -17,15 +18,21 @@ impl<R: ResourceUsageRepository> ListAllFutureResourceUsagesUseCase<R> {
         Self { repository }
     }
 
-    /// 全ての未来のリソース使用予定を取得
+    /// 指定期間に重なるリソース使用予定を取得
+    ///
+    /// # Arguments
+    /// * `time_period` - 一覧する期間。どこまで先を見るかは呼び出し側が決める
     ///
     /// # Returns
     /// ResourceUsageのリスト（時系列順）
     ///
     /// # Errors
     /// - リポジトリエラー
-    pub async fn execute(&self) -> Result<Vec<ResourceUsage>, ApplicationError> {
-        let mut usages = self.repository.find_future().await?;
+    pub async fn execute(
+        &self,
+        time_period: &TimePeriod,
+    ) -> Result<Vec<ResourceUsage>, ApplicationError> {
+        let mut usages = self.repository.find_overlapping(time_period).await?;
 
         // 開始時刻でソート
         usages.sort_by_key(|a| a.time_period().start());

--- a/src/application/usecases/list_user_resource_usages.rs
+++ b/src/application/usecases/list_user_resource_usages.rs
@@ -1,5 +1,6 @@
 use crate::application::error::ApplicationError;
 use crate::domain::aggregates::resource_usage::entity::ResourceUsage;
+use crate::domain::aggregates::resource_usage::value_objects::TimePeriod;
 use crate::domain::common::EmailAddress;
 use crate::domain::ports::repositories::ResourceUsageRepository;
 use std::sync::Arc;
@@ -18,10 +19,11 @@ impl<R: ResourceUsageRepository> ListUserResourceUsagesUseCase<R> {
         Self { repository }
     }
 
-    /// 特定のユーザーが所有するリソース使用予定の一覧を取得
+    /// 指定期間に重なる、特定のユーザーが所有するリソース使用予定の一覧を取得
     ///
     /// # Arguments
     /// * `owner_email` - 所有者のメールアドレス
+    /// * `time_period` - 一覧する期間。どこまで先を見るかは呼び出し側が決める
     ///
     /// # Returns
     /// ResourceUsageのリスト（時系列順）
@@ -31,8 +33,12 @@ impl<R: ResourceUsageRepository> ListUserResourceUsagesUseCase<R> {
     pub async fn execute(
         &self,
         owner_email: &EmailAddress,
+        time_period: &TimePeriod,
     ) -> Result<Vec<ResourceUsage>, ApplicationError> {
-        let mut usages = self.repository.find_by_owner(owner_email).await?;
+        let mut usages = self
+            .repository
+            .find_by_owner(owner_email, time_period)
+            .await?;
 
         // 開始時刻でソート
         usages.sort_by_key(|a| a.time_period().start());

--- a/src/application/usecases/notify_future_resource_usage_changes.rs
+++ b/src/application/usecases/notify_future_resource_usage_changes.rs
@@ -1,7 +1,9 @@
 use crate::application::ApplicationError;
 use crate::domain::aggregates::resource_usage::entity::ResourceUsage;
+use crate::domain::aggregates::resource_usage::value_objects::TimePeriod;
 use crate::domain::ports::repositories::ResourceUsageRepository;
 use crate::domain::ports::{NotificationEvent, Notifier};
+use chrono::{Duration, Utc};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -22,6 +24,11 @@ where
 {
     repository: Arc<R>,
     notifier: N,
+    /// 変更を監視する期間の長さ
+    ///
+    /// 前回と今回の状態を突き合わせて差分を通知するため、範囲を狭めると
+    /// 範囲外に出た予約が削除として扱われる。用途に見合う長さを与える必要がある。
+    watch_window: Duration,
     previous_state: tokio::sync::Mutex<HashMap<String, ResourceUsage>>,
 }
 
@@ -38,10 +45,16 @@ where
     ///
     /// # Errors
     /// リポジトリから初期状態の取得に失敗した場合
-    pub async fn new(repository: Arc<R>, notifier: N) -> Result<Self, ApplicationError> {
+    /// * `watch_window` - 変更を監視する期間の長さ（現在時刻から先へこの長さ）
+    pub async fn new(
+        repository: Arc<R>,
+        notifier: N,
+        watch_window: Duration,
+    ) -> Result<Self, ApplicationError> {
         let instance = Self {
             repository,
             notifier,
+            watch_window,
             previous_state: tokio::sync::Mutex::new(HashMap::new()),
         };
 
@@ -76,7 +89,10 @@ where
     async fn fetch_current_usages(
         &self,
     ) -> Result<HashMap<String, ResourceUsage>, ApplicationError> {
-        let usages = self.repository.find_future().await?;
+        // 監視する期間は現在時刻を起点に取り直す。ポーリングごとに窓が前へ進む
+        let now = Utc::now();
+        let window = TimePeriod::new(now, now + self.watch_window)?;
+        let usages = self.repository.find_overlapping(&window).await?;
         Ok(usages
             .into_iter()
             .map(|usage| (usage.id().as_str().to_string(), usage))

--- a/src/application/usecases/reconcile_observed_usages.rs
+++ b/src/application/usecases/reconcile_observed_usages.rs
@@ -1,7 +1,7 @@
 use crate::application::error::ApplicationError;
 use crate::domain::aggregates::identity_link::value_objects::ExternalIdentity;
 use crate::domain::aggregates::resource_usage::entity::ResourceUsage;
-use crate::domain::aggregates::resource_usage::value_objects::Resource;
+use crate::domain::aggregates::resource_usage::value_objects::{Resource, TimePeriod};
 use crate::domain::common::EmailAddress;
 use crate::domain::ports::repositories::{IdentityLinkRepository, ResourceUsageRepository};
 use crate::domain::ports::{
@@ -100,7 +100,9 @@ where
     pub async fn poll_once(&self) -> Result<(), ApplicationError> {
         let observed = self.observer.observe_active_usages().await?;
         let now = Utc::now();
-        let current_usages = self.repository.find_future().await?;
+        // 突合の相手は「今この瞬間に進行中の予約」だけなので、現在時刻を含む最小の期間を問う
+        let in_progress = TimePeriod::new(now, now + Duration::seconds(1))?;
+        let current_usages = self.repository.find_overlapping(&in_progress).await?;
 
         let mut unreserved = Vec::new();
 

--- a/src/application/usecases/reconcile_observed_usages_tests.rs
+++ b/src/application/usecases/reconcile_observed_usages_tests.rs
@@ -618,3 +618,40 @@ async fn test_grouped_proposal_is_sent_only_once_per_session() {
         "同じ観測セッションへの提案は一度だけ"
     );
 }
+
+#[tokio::test]
+async fn a_reservation_that_starts_later_today_does_not_count_as_in_progress() {
+    let (usecase, repo, observer, identity_repo, proposal_notifier, notifier) = make_usecase(15);
+    identity_repo.add_link("user@example.com", os_system(), "kkawaguchi");
+
+    // 同じGPUに、今日のうちに始まる予約がある（まだ進行中ではない）
+    let now = Utc::now();
+    let later_today = make_reservation(
+        "someone-else@example.com",
+        now + Duration::hours(3),
+        now + Duration::hours(5),
+    );
+    repo.save(&later_today).await.unwrap();
+
+    observer.set_active_usages(vec![ObservedUsage::new(
+        gpu_resource(),
+        ExternalIdentity::new(os_system(), "kkawaguchi".to_string()),
+        now - Duration::minutes(20),
+    )]);
+
+    usecase.poll_once().await.unwrap();
+
+    // 進行中の予約はないので、未予約利用として提案される
+    let proposals = proposal_notifier.sent_proposals();
+    assert_eq!(
+        proposals.len(),
+        1,
+        "先の予約は突合の相手にならず、今の利用は未予約として扱われるべき"
+    );
+    assert_eq!(proposals[0].owner_email().as_str(), "user@example.com");
+    // 予約者が違う相手と照合してしまうと無断使用として通知されてしまう
+    assert!(
+        notifier.notified().is_empty(),
+        "先の予約を進行中とみなして無断使用通知を出してはいけない"
+    );
+}

--- a/src/bin/lab-resource-manager.rs
+++ b/src/bin/lab-resource-manager.rs
@@ -36,6 +36,13 @@ use lab_resource_manager::{
 use slack_morphism::prelude::*;
 use std::sync::Arc;
 
+/// 予約の変更を監視する期間の長さ
+///
+/// 前回と今回の状態を突き合わせて差分を通知するため、この長さを縮めると
+/// 範囲外に出た予約が削除として通知される。繰り返し予約は個々の予定へ展開されるので、
+/// 上限なしにはできない。
+const NOTIFICATION_WATCH_WINDOW_DAYS: i64 = 60;
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // tracingの初期化（RUST_LOGで制御、未設定時はinfo）
@@ -136,9 +143,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let notifier = NotificationRouter::new(resource_config.as_ref().clone(), identity_repo.clone());
     let notify_usecase = Arc::new(
-        NotifyFutureResourceUsageChangesUseCase::new(resource_usage_repo.clone(), notifier)
-            .await
-            .map_err(|e| format!("通知UseCaseの初期化に失敗: {}", e))?,
+        NotifyFutureResourceUsageChangesUseCase::new(
+            resource_usage_repo.clone(),
+            notifier,
+            ChronoDuration::days(NOTIFICATION_WATCH_WINDOW_DAYS),
+        )
+        .await
+        .map_err(|e| format!("通知UseCaseの初期化に失敗: {}", e))?,
     );
 
     // Slackインフラ

--- a/src/domain/ports/repositories/resource_usage.rs
+++ b/src/domain/ports/repositories/resource_usage.rs
@@ -10,6 +10,12 @@ use async_trait::async_trait;
 
 /// ResourceUsage集約のリポジトリポート
 ///
+/// # 検索する期間
+/// 検索は期間を指定して行う。「今後の予約」のように終わりのない範囲を指定する手段は
+/// 用意していない。繰り返し予約は個々の予定へ展開されるため、終わりのない検索は
+/// カレンダーが展開できる限りの予定を返してしまう。どこまでを対象とするかは
+/// 用途によって異なるため、呼び出し側が決める。
+///
 /// # 予約として扱う範囲
 /// 永続化層のレコードのうち、`ResourceUsage`として解釈できるものだけが予約である。
 /// 解釈できないレコードは予約ではなく、このモデルの外にある。検索結果に現れないのは
@@ -25,17 +31,6 @@ pub trait ResourceUsageRepository {
     /// IDでResourceUsageを検索
     async fn find_by_id(&self, id: &UsageId) -> Result<Option<ResourceUsage>, RepositoryError>;
 
-    /// 未来のリソース使用状況を取得する（進行中および今後予定されているもの）
-    ///
-    /// このメソッドは、終了時刻が現在時刻より後のリソース使用状況を返します。
-    /// 過去に終了したリソース使用は含まれません。
-    ///
-    /// # Returns
-    /// 進行中および未来のリソース使用状況のリスト
-    ///
-    /// (Get future resource usages - ongoing and upcoming)
-    async fn find_future(&self) -> Result<Vec<ResourceUsage>, RepositoryError>;
-
     /// 指定期間と重複するResourceUsageを検索
     ///
     /// 終了済みのリソース使用も含めて返します。過去の期間に対する予約（実利用検知に
@@ -46,10 +41,13 @@ pub trait ResourceUsageRepository {
         time_period: &TimePeriod,
     ) -> Result<Vec<ResourceUsage>, RepositoryError>;
 
-    /// 特定のユーザーが所有するResourceUsageを検索
+    /// 指定期間に重なる、特定のユーザーが所有するResourceUsageを検索
+    ///
+    /// 対象とする期間は呼び出し側が決める（`find_overlapping`と同じ）。
     async fn find_by_owner(
         &self,
         owner_email: &EmailAddress,
+        time_period: &TimePeriod,
     ) -> Result<Vec<ResourceUsage>, RepositoryError>;
 
     /// ResourceUsageを保存（新規作成または更新）

--- a/src/domain/services/resource_usage/conflict_checker.rs
+++ b/src/domain/services/resource_usage/conflict_checker.rs
@@ -106,10 +106,6 @@ mod tests {
             unimplemented!("このテストでは使用しない")
         }
 
-        async fn find_future(&self) -> Result<Vec<ResourceUsage>, RepositoryError> {
-            unimplemented!("このテストでは使用しない")
-        }
-
         async fn find_overlapping(
             &self,
             _time_period: &TimePeriod,
@@ -120,6 +116,7 @@ mod tests {
         async fn find_by_owner(
             &self,
             _owner_email: &EmailAddress,
+            _time_period: &TimePeriod,
         ) -> Result<Vec<ResourceUsage>, RepositoryError> {
             unimplemented!("このテストでは使用しない")
         }

--- a/src/infrastructure/repositories/resource_usage/google_calendar/repository.rs
+++ b/src/infrastructure/repositories/resource_usage/google_calendar/repository.rs
@@ -12,7 +12,7 @@ use crate::domain::ports::repositories::{
 };
 use crate::infrastructure::config::ResourceConfig;
 use async_trait::async_trait;
-use chrono::{DateTime, Duration, Utc};
+use chrono::{DateTime, Utc};
 use google_calendar3::{
     CalendarHub,
     api::Event,
@@ -51,13 +51,6 @@ const RESERVATION_ID_LINE_PREFIX: &str = "予約ID: ";
 fn event_id_for(usage_id: &UsageId) -> String {
     usage_id.as_str().replace('-', "")
 }
-
-/// 「今後の予約」として扱う期間の上限
-///
-/// 繰り返し予約は個々の予定へ展開して取得するため、上限を設けないとカレンダーが
-/// 展開できる限り（数十年先まで）返ってくる。予約の閲覧・変更通知にとって遠い将来は
-/// 意味を持たないので、ここで区切る。
-const FUTURE_HORIZON: Duration = Duration::days(365);
 
 /// キャンセル済みイベントのstatus値
 const EVENT_STATUS_CANCELLED: &str = "cancelled";
@@ -788,18 +781,9 @@ impl ResourceUsageRepository for GoogleCalendarUsageRepository {
         Ok(Some(Self::with_id(usage, id)?))
     }
 
-    async fn find_future(&self) -> Result<Vec<ResourceUsage>, RepositoryError> {
-        // 終了時刻が現在より後のイベントに限る。開始時刻の下限は設けないため、
-        // 進行中のイベント（開始時刻が過去）も含まれる。
-        let now = Utc::now();
-        let events = self.fetch_events(now, Some(now + FUTURE_HORIZON)).await?;
-
-        Ok(self.parse_events(events))
-    }
-
     /// 指定期間と重複するResourceUsageを検索
     ///
-    /// 対象期間そのものをカレンダーに問い合わせる。`find_future`は使わない。
+    /// 対象期間そのものをカレンダーに問い合わせる。終了済みかどうかで絞ってはいけない。
     /// 事後予約のように過去の期間を予約する場合、相手の予約が既に終了していても
     /// 競合は競合であり、終了済みを除外すると重複予約を許してしまう。
     async fn find_overlapping(
@@ -817,15 +801,14 @@ impl ResourceUsageRepository for GoogleCalendarUsageRepository {
             .collect())
     }
 
-    /// 特定のユーザーが所有するResourceUsageを検索
-    ///
-    /// 進行中および今後の予約のみを対象とする（終了済みの予約は返さない）。
     async fn find_by_owner(
         &self,
         owner_email: &EmailAddress,
+        time_period: &TimePeriod,
     ) -> Result<Vec<ResourceUsage>, RepositoryError> {
-        let all_usages = self.find_future().await?;
-        Ok(all_usages
+        Ok(self
+            .find_overlapping(time_period)
+            .await?
             .into_iter()
             .filter(|usage| usage.owner_email() == owner_email)
             .collect())

--- a/src/infrastructure/repositories/resource_usage/google_calendar/repository_tests.rs
+++ b/src/infrastructure/repositories/resource_usage/google_calendar/repository_tests.rs
@@ -371,7 +371,7 @@ async fn find_overlapping_skips_unparsable_events_but_keeps_the_rest() {
 }
 
 #[tokio::test]
-async fn find_future_excludes_reservation_that_already_ended() {
+async fn a_window_starting_now_excludes_reservations_that_already_ended() {
     let now = Utc::now();
     let ended = reservation_event(
         "already-ended",
@@ -382,16 +382,14 @@ async fn find_future_excludes_reservation_that_already_ended() {
     );
     let (repository, _gateway, _mapping_path) = repository_with(vec![ended]);
 
-    let future = repository.find_future().await.unwrap();
+    let window = TimePeriod::new(now, now + Duration::days(30)).unwrap();
+    let future = repository.find_overlapping(&window).await.unwrap();
 
-    assert!(
-        future.is_empty(),
-        "終了済みの予約は今後の予約として扱わない"
-    );
+    assert!(future.is_empty(), "終了済みの予約は今後の期間に含まれない");
 }
 
 #[tokio::test]
-async fn find_future_keeps_ongoing_reservation() {
+async fn a_window_starting_now_keeps_an_ongoing_reservation() {
     let now = Utc::now();
     let ongoing = reservation_event(
         "ongoing",
@@ -402,7 +400,8 @@ async fn find_future_keeps_ongoing_reservation() {
     );
     let (repository, _gateway, _mapping_path) = repository_with(vec![ongoing]);
 
-    let future = repository.find_future().await.unwrap();
+    let window = TimePeriod::new(now, now + Duration::days(30)).unwrap();
+    let future = repository.find_overlapping(&window).await.unwrap();
 
     assert_eq!(
         future.len(),
@@ -868,47 +867,4 @@ async fn updating_a_saved_reservation_updates_the_event_instead_of_inserting_aga
         usage.id().as_str().replace('-', ""),
         "同じイベントIDを更新するべき"
     );
-}
-
-#[tokio::test]
-async fn find_future_bounds_how_far_ahead_it_looks() {
-    // 繰り返し予約は個々の予定へ展開されるため、上限を設けないとカレンダーが
-    // 展開できる限り（数十年先まで）返ってくる
-    let (repository, gateway, _mapping_path) = repository_with(vec![]);
-
-    repository.find_future().await.unwrap();
-
-    let queries = gateway.queries();
-    assert_eq!(queries.len(), 1);
-    let time_max = queries[0]
-        .time_max
-        .expect("今後の予約を探す範囲には上限が必要");
-    let horizon = time_max - queries[0].time_min;
-    assert!(
-        horizon <= Duration::days(366),
-        "上限が遠すぎる: {}日",
-        horizon.num_days()
-    );
-    assert!(
-        horizon >= Duration::days(90),
-        "上限が近すぎると先の予約が見えなくなる: {}日",
-        horizon.num_days()
-    );
-}
-
-#[tokio::test]
-async fn find_future_still_returns_a_reservation_inside_the_horizon() {
-    let now = Utc::now();
-    let soon = reservation_event(
-        "within-horizon",
-        "0",
-        "owner@example.com",
-        now + Duration::days(30),
-        now + Duration::days(30) + Duration::hours(1),
-    );
-    let (repository, _gateway, _mapping_path) = repository_with(vec![soon]);
-
-    let future = repository.find_future().await.unwrap();
-
-    assert_eq!(future.len(), 1, "上限内の予約は返るべき");
 }

--- a/src/infrastructure/repositories/resource_usage/mock.rs
+++ b/src/infrastructure/repositories/resource_usage/mock.rs
@@ -37,17 +37,6 @@ impl ResourceUsageRepository for MockUsageRepository {
         Ok(storage.get(id.as_str()).cloned())
     }
 
-    async fn find_future(&self) -> Result<Vec<ResourceUsage>, RepositoryError> {
-        // ポートの契約どおり、終了済みのリソース使用は返さない
-        let now = chrono::Utc::now();
-        let storage = self.storage.lock().unwrap();
-        Ok(storage
-            .values()
-            .filter(|usage| usage.time_period().end() > now)
-            .cloned()
-            .collect())
-    }
-
     async fn find_overlapping(
         &self,
         time_period: &TimePeriod,
@@ -64,11 +53,13 @@ impl ResourceUsageRepository for MockUsageRepository {
     async fn find_by_owner(
         &self,
         owner_email: &crate::domain::common::EmailAddress,
+        time_period: &TimePeriod,
     ) -> Result<Vec<ResourceUsage>, RepositoryError> {
         let storage = self.storage.lock().unwrap();
         let owned: Vec<ResourceUsage> = storage
             .values()
             .filter(|usage| usage.owner_email() == owner_email)
+            .filter(|usage| usage.time_period().overlaps_with(time_period))
             .cloned()
             .collect();
         Ok(owned)

--- a/src/interface/mcp/server.rs
+++ b/src/interface/mcp/server.rs
@@ -72,6 +72,19 @@ fn resolved_caller(parts: &http::request::Parts) -> Result<EmailAddress, ErrorDa
 }
 
 /// アプリケーションエラーをツールレベルのエラーとして呼び出し元に見せる
+/// 予約一覧が対象とする期間の長さ
+///
+/// 繰り返し予約は個々の予定へ展開されるため、上限を設けないと数十年先の予定まで返る。
+/// エージェントが把握したいのは手近な予定なので、ここで区切る。
+const LISTING_WINDOW_DAYS: i64 = 60;
+
+/// 一覧の対象期間（現在時刻から`LISTING_WINDOW_DAYS`日先まで）
+fn listing_window()
+-> Result<TimePeriod, crate::domain::aggregates::resource_usage::errors::ResourceUsageError> {
+    let now = chrono::Utc::now();
+    TimePeriod::new(now, now + chrono::Duration::days(LISTING_WINDOW_DAYS))
+}
+
 fn tool_error(message: impl std::fmt::Display) -> CallToolResult {
     CallToolResult::error(vec![ContentBlock::text(message.to_string())])
 }
@@ -172,7 +185,11 @@ where
 
     #[tool(description = "今後（進行中含む）の全ての予約を一覧表示する")]
     async fn list_all_reservations(&self) -> Result<CallToolResult, ErrorData> {
-        match self.list_all_usecase.execute().await {
+        let window = match listing_window() {
+            Ok(window) => window,
+            Err(e) => return Ok(tool_error(e)),
+        };
+        match self.list_all_usecase.execute(&window).await {
             Ok(usages) => {
                 let dtos: Vec<ReservationDto> = usages.iter().map(ReservationDto::from).collect();
                 Ok(success_json(&dtos))
@@ -187,7 +204,11 @@ where
         Extension(parts): Extension<http::request::Parts>,
     ) -> Result<CallToolResult, ErrorData> {
         let caller = resolved_caller(&parts)?;
-        match self.list_mine_usecase.execute(&caller).await {
+        let window = match listing_window() {
+            Ok(window) => window,
+            Err(e) => return Ok(tool_error(e)),
+        };
+        match self.list_mine_usecase.execute(&caller, &window).await {
             Ok(usages) => {
                 let dtos: Vec<ReservationDto> = usages.iter().map(ReservationDto::from).collect();
                 Ok(success_json(&dtos))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,8 +64,14 @@
 //! // (Slack, Mock, etc.) based on config/resources.toml
 //! let notifier = NotificationRouter::new(config, identity_repo);
 //!
-//! // Create and run use case
-//! let usecase = NotifyFutureResourceUsageChangesUseCase::new(repository, notifier).await?;
+//! // Create and run use case. The watch window states how far ahead changes are tracked;
+//! // recurring reservations expand into individual instances, so it cannot be unbounded.
+//! let usecase = NotifyFutureResourceUsageChangesUseCase::new(
+//!     repository,
+//!     notifier,
+//!     chrono::Duration::days(60),
+//! )
+//! .await?;
 //! usecase.poll_once().await?;
 //! # Ok(())
 //! # }


### PR DESCRIPTION
## Why

`find_future()` decided for its callers how far ahead to look. That was tolerable while "the future" was a small set, but v1.5.0 started expanding recurring reservations into individual instances, and an unbounded search then returns every instance the calendar can generate — a weekly room booking became 1,442 reservations reaching into 2040.

#115 bounded it at one year inside the repository. That stopped the bleeding but hid the real problem: **the callers want different things, and none of them wants a year.**

| caller | what it actually needs |
|---|---|
| `ReconcileObservedUsagesUseCase` | only what is **in progress right now** — it matches live GPU usage against reservations |
| MCP `list_all_reservations` / `list_my_reservations` | a handful of weeks |
| change notification | a window it compares between polls |

Reconciliation was fetching a year of reservations every 60 seconds to answer a question about the current instant.

## What

Remove `find_future()` and give `find_by_owner` a period, so every search states its range. The port documents that there is deliberately no way to ask for an unbounded future.

- **Reconciliation** asks for the instant it is reconciling
- **MCP listings** look 60 days ahead (`LISTING_WINDOW_DAYS`)
- **Change notification** takes its watch window at construction. Narrowing it would make reservations that fall outside look deleted, so it is stated where the trade-off is visible rather than buried in the repository
- `FUTURE_HORIZON` from #115 is gone — the repository no longer picks a range

## Test plan

- [x] `a_reservation_that_starts_later_today_does_not_count_as_in_progress` — a reservation starting in 3 hours must not be matched against current usage. Without a bounded query it would be, and since its owner differs it would have produced an unauthorized-usage DM to the wrong person
- [x] Existing repository tests reworded to query an explicit window (`a_window_starting_now_excludes_reservations_that_already_ended`, `..._keeps_an_ongoing_reservation`)
- [x] The two horizon tests from #115 are removed — they asserted a constant the repository no longer owns
- [x] `cargo test --workspace --all-features` — 135 passed
- [x] `cargo clippy --workspace --all-targets --all-features -- -Dwarnings` — clean
- [x] `cargo build --workspace --all-targets --all-features` with `RUSTFLAGS=-D warnings` — clean
- [x] `cargo fmt --all --check`
- [ ] The mapping file still holds ~1,450 entries allocated while reads were writing (before #109). Harmless now; pruning tracked under #111

## Note

The window values (60 days) are placed at the callers, so they can differ per use and be made configurable later without touching the port.