### PR TITLE
fix: send one unauthorized-usage notice per reservation

### DIFF
--- a/src/application/usecases/reconcile_observed_usages.rs
+++ b/src/application/usecases/reconcile_observed_usages.rs
@@ -22,6 +22,11 @@ const SESSION_GROUPING_WINDOW: Duration = Duration::minutes(5);
 /// 提案済みの機会を表すキー（利用者・正規化したリソース名・開始時刻）
 type ProposedSessionKey = (ExternalIdentity, Vec<String>, DateTime<Utc>);
 
+/// 無断使用を知らせた機会を表すキー（利用者・予約ID・その機会の開始時刻）
+///
+/// 予約単位で数えるため、同じ予約が複数のリソースを押さえていても1回で済む。
+type NotifiedUnauthorizedKey = (ExternalIdentity, String, DateTime<Utc>);
+
 /// 実サーバーの利用状況と予約を突き合わせ、未予約利用の提案・無断使用の通知を行うユースケース
 ///
 /// # 検知ロジック
@@ -55,7 +60,7 @@ where
     unreserved_threshold: Duration,
     duration_candidates: Vec<Duration>,
     proposed_keys: tokio::sync::Mutex<HashSet<ProposedSessionKey>>,
-    notified_unauthorized_keys: tokio::sync::Mutex<HashSet<(Resource, DateTime<Utc>)>>,
+    notified_unauthorized_keys: tokio::sync::Mutex<HashSet<NotifiedUnauthorizedKey>>,
 }
 
 impl<R, O, I, P, U> ReconcileObservedUsagesUseCase<R, O, I, P, U>
@@ -108,25 +113,49 @@ where
         let mut unreserved = Vec::new();
         let mut reserved = 0_usize;
         let mut failures = 0_usize;
+        // 同じ予約の複数リソースを使っていても知らせるのは1回なので、予約ごとにまとめる
+        let mut reserved_by_usage: HashMap<(ExternalIdentity, String), &ObservedUsage> =
+            HashMap::new();
 
         for usage in &observed {
             match Self::find_active_reservation(&current_usages, usage.resource(), now) {
                 Some(reservation) => {
                     reserved += 1;
-                    if let Err(e) = self.reconcile_reserved(usage, reservation).await {
-                        failures += 1;
-                        error!(
-                            resource = %usage.resource(),
-                            error = %e,
-                            "reconciling an observed usage failed"
-                        );
-                    }
+                    let key = (
+                        usage.external_identity().clone(),
+                        reservation.id().as_str().to_string(),
+                    );
+                    // 同じ機会の開始時刻として、最も早い観測を代表に選ぶ
+                    reserved_by_usage
+                        .entry(key)
+                        .and_modify(|earliest| {
+                            if usage.active_since() < earliest.active_since() {
+                                *earliest = usage;
+                            }
+                        })
+                        .or_insert(usage);
                 }
                 // 未予約の利用は、同じ機会に使い始めた分をまとめて提案するため一旦集める
                 None if now - usage.active_since() >= self.unreserved_threshold => {
                     unreserved.push(usage.clone());
                 }
                 None => {}
+            }
+        }
+
+        for observed_usage in reserved_by_usage.into_values() {
+            let Some(reservation) =
+                Self::find_active_reservation(&current_usages, observed_usage.resource(), now)
+            else {
+                continue;
+            };
+            if let Err(e) = self.reconcile_reserved(observed_usage, reservation).await {
+                failures += 1;
+                error!(
+                    resource = %observed_usage.resource(),
+                    error = %e,
+                    "reconciling an observed usage failed"
+                );
             }
         }
 
@@ -222,9 +251,13 @@ where
             return Ok(());
         }
 
-        // 同一の観測セッションに対する再通知を防ぐ（提案と同じくUX上のスパム防止であり、
+        // 同一の機会に対する再通知を防ぐ（提案と同じくUX上のスパム防止であり、
         // 送信成功後にのみ記録することで失敗時の再試行を保つ）
-        let key = (observed.resource().clone(), observed.active_since());
+        let key = (
+            observed.external_identity().clone(),
+            reservation.id().as_str().to_string(),
+            observed.active_since(),
+        );
         if self.notified_unauthorized_keys.lock().await.contains(&key) {
             return Ok(());
         }

--- a/src/application/usecases/reconcile_observed_usages_tests.rs
+++ b/src/application/usecases/reconcile_observed_usages_tests.rs
@@ -655,3 +655,90 @@ async fn a_reservation_that_starts_later_today_does_not_count_as_in_progress() {
         "先の予約を進行中とみなして無断使用通知を出してはいけない"
     );
 }
+
+#[tokio::test]
+async fn using_several_gpus_of_one_reservation_notifies_once() {
+    let (usecase, repo, observer, identity_repo, _proposal_notifier, notifier) = make_usecase(15);
+    identity_repo.add_link("other@example.com", os_system(), "kkawaguchi");
+
+    // 1件の予約が2枚のGPUを押さえていて、別の利用者がその2枚を使っている
+    let now = Utc::now();
+    let reservation = ResourceUsage::new(
+        EmailAddress::new("owner@example.com".to_string()).unwrap(),
+        TimePeriod::new(now - Duration::hours(1), now + Duration::hours(1)).unwrap(),
+        vec![gpu_resource(), gpu_resource_device1()],
+        None,
+    )
+    .unwrap();
+    repo.save(&reservation).await.unwrap();
+
+    let active_since = now - Duration::minutes(20);
+    observer.set_active_usages(vec![
+        ObservedUsage::new(
+            gpu_resource(),
+            ExternalIdentity::new(os_system(), "kkawaguchi".to_string()),
+            active_since,
+        ),
+        ObservedUsage::new(
+            gpu_resource_device1(),
+            ExternalIdentity::new(os_system(), "kkawaguchi".to_string()),
+            active_since + Duration::seconds(4),
+        ),
+    ]);
+
+    usecase.poll_once().await.unwrap();
+
+    let notified = notifier.notified();
+    assert_eq!(
+        notified.len(),
+        1,
+        "ひとつの予約に対する無断使用の通知は、枚数分ではなく1回であるべき"
+    );
+    // 通知の本文は予約全体を示すため、2枚の情報は1通に収まる
+    assert_eq!(notified[0].0.resources().len(), 2);
+    assert_eq!(notified[0].1.as_str(), "other@example.com");
+}
+
+#[tokio::test]
+async fn using_gpus_of_two_different_reservations_notifies_for_each() {
+    let (usecase, repo, observer, identity_repo, _proposal_notifier, notifier) = make_usecase(15);
+    identity_repo.add_link("other@example.com", os_system(), "kkawaguchi");
+
+    // 別々の予約が1枚ずつ押さえている場合は、それぞれ知らせる必要がある
+    let now = Utc::now();
+    for (owner, resource) in [
+        ("owner-a@example.com", gpu_resource()),
+        ("owner-b@example.com", gpu_resource_device1()),
+    ] {
+        let reservation = ResourceUsage::new(
+            EmailAddress::new(owner.to_string()).unwrap(),
+            TimePeriod::new(now - Duration::hours(1), now + Duration::hours(1)).unwrap(),
+            vec![resource],
+            None,
+        )
+        .unwrap();
+        repo.save(&reservation).await.unwrap();
+    }
+
+    let active_since = now - Duration::minutes(20);
+    observer.set_active_usages(vec![
+        ObservedUsage::new(
+            gpu_resource(),
+            ExternalIdentity::new(os_system(), "kkawaguchi".to_string()),
+            active_since,
+        ),
+        ObservedUsage::new(
+            gpu_resource_device1(),
+            ExternalIdentity::new(os_system(), "kkawaguchi".to_string()),
+            active_since,
+        ),
+    ]);
+
+    usecase.poll_once().await.unwrap();
+
+    assert_eq!(
+        notifier.notified().len(),
+        2,
+        "予約が別なら、それぞれの予約者について知らせるべき"
+    );
+}


### PR DESCRIPTION
## Why

Found by holding two GPUs that belonged to one else's reservation on the live service.

Suppression was keyed on the **resource**:

```rust
let key = (observed.resource().clone(), observed.active_since());
```

A reservation holding several GPUs is observed once per GPU, and each observation resolves to the same reservation, so `reconcile_reserved` runs once per GPU with distinct keys — nothing is suppressed.

Each of those notices already describes the **whole** reservation:

```
🚫 他の人が予約中のリソースを使用しています
👤 予約者  example@gmail.com
💻 予約リソース
Freccia / RTX PRO 6000 Blackwell Max-Q / GPU:2
Freccia / RTX PRO 6000 Blackwell Max-Q / GPU:3
```

So using two GPUs of one booking delivers **the same message twice**. Ten GPUs, ten identical copies.

This is also asymmetric with the proposal path: #104 made proposals group per occasion for exactly this reason, and this path was left keyed per resource.

## What

Group observations that match a reservation by `(user, reservation)` before notifying, choosing the earliest observation as the occasion's start, and suppress on `(user, reservation id, started at)`.

Keying on `(reservation id, active_since)` alone would not have been enough — start times differ by seconds per resource when GPUs are launched one at a time, so the same booking would still notify more than once.

Observations spanning **separate** reservations still notify separately: each has a different person to point at.

**The message is unchanged.** It already listed every resource of the reservation. Only the number of copies changes.

## Test plan

- [x] `using_several_gpus_of_one_reservation_notifies_once` — confirmed failing first (`left: 2`), matching production. Also asserts the single notice still carries both resources
- [x] `using_gpus_of_two_different_reservations_notifies_for_each` — guards against over-suppressing; two bookings must still produce two notices
- [x] `cargo test --workspace --all-features` — 137 passed
- [x] `cargo clippy --workspace --all-targets --all-features -- -Dwarnings` — clean
- [x] `cargo fmt --all --check`
- [ ] Not re-verified against Slack. The previous check took holding two GPUs of a live reservation; worth repeating once deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KHaZgaoJcQjDGXZF9PJ9S