### PR TITLE
fix: list resources one per line in the proposal DM

### DIFF
--- a/src/infrastructure/reservation_proposal/slack.rs
+++ b/src/infrastructure/reservation_proposal/slack.rs
@@ -7,6 +7,8 @@ use crate::domain::ports::repositories::IdentityLinkRepository;
 use crate::domain::ports::reservation_proposal::{
     ReservationProposal, ReservationProposalNotifier,
 };
+use crate::infrastructure::config::ResourceStyle;
+use crate::infrastructure::notifier::formatter::format_resources_styled;
 use async_trait::async_trait;
 use chrono::Duration;
 use serde::{Deserialize, Serialize};
@@ -108,8 +110,8 @@ impl ReservationProposalNotifier for SlackReservationProposalNotifier {
             })?;
 
         let text = format!(
-            "{} が予約なしで使用中です。事後予約を作成しますか？",
-            format_resource_list(&proposal)
+            "⏱️ 予約なしでリソースを使用しています\n\n💻 使用中のリソース\n{}\n\nこのまま事後予約を作成しますか？",
+            format_resources_styled(proposal.resources(), ResourceStyle::Full)
         );
         let blocks = build_proposal_blocks(&proposal, &gpus, &text);
 
@@ -152,16 +154,6 @@ fn collect_gpus(proposal: &ReservationProposal) -> Result<Vec<Gpu>, Notification
     }
 
     Ok(gpus)
-}
-
-/// 提案対象のリソースを読みやすく並べる
-fn format_resource_list(proposal: &ReservationProposal) -> String {
-    proposal
-        .resources()
-        .iter()
-        .map(|resource| resource.to_string())
-        .collect::<Vec<_>>()
-        .join(", ")
 }
 
 /// 事後予約提案のBlock Kitメッセージを構築する（純粋関数、ユニットテスト対象）
@@ -346,5 +338,16 @@ mod tests {
         let json = serde_json::to_string(&payload).unwrap();
         let decoded: ProposalAcceptPayload = serde_json::from_str(&json).unwrap();
         assert_eq!(decoded, payload);
+    }
+    #[test]
+    fn the_message_lists_each_resource_on_its_own_line() {
+        let proposal = sample_proposal_with_devices(vec![4, 5, 6], vec![Duration::hours(1)]);
+
+        let listed = format_resources_styled(proposal.resources(), ResourceStyle::Full);
+
+        assert_eq!(
+            listed, "Thalys / A100 / GPU:4\nThalys / A100 / GPU:5\nThalys / A100 / GPU:6",
+            "枚数が増えても1行に詰めず、通知と同じ表現で並べる"
+        );
     }
 }


### PR DESCRIPTION
## Why

The proposal DM joined resources with commas. Three GPUs produced this:

```
Freccia GPU#4 (RTX PRO 6000 Blackwell Max-Q), Freccia GPU#5 (RTX PRO 6000 Blackwell Max-Q), Freccia GPU#6 (RTX PRO 6000 Blackwell Max-Q) が予約なしで使用中です。事後予約を作成しますか？
```

Two problems, and the second was the one I had missed.

**It does not wrap into anything readable.** The reader has to reach the end of a long sentence to learn what the message is about. Every other message in the system puts one resource per line.

**It spells resources differently from every other message.** The proposal used `Resource`'s `Display` (`Freccia GPU#4 (RTX PRO 6000 Blackwell Max-Q)`), while reservation notices and the unauthorized-usage DM go through `format_resources_styled` (`Freccia / RTX PRO 6000 Blackwell Max-Q / GPU:4`). The same GPU was written two ways depending on which message you were reading.

I introduced both in #104 by writing a local `format_resource_list` with `join(", ")` instead of reaching for the formatter that already existed.

## What

```
⏱️ 予約なしでリソースを使用しています

💻 使用中のリソース
Freccia / RTX PRO 6000 Blackwell Max-Q / GPU:4
Freccia / RTX PRO 6000 Blackwell Max-Q / GPU:5
Freccia / RTX PRO 6000 Blackwell Max-Q / GPU:6

このまま事後予約を作成しますか？
```

Uses `format_resources_styled(.., ResourceStyle::Full)` — the same path the notifier and the unauthorized-usage DM take — and adopts the heading shape of the unauthorized-usage DM, so the two DMs a member might receive look like they come from the same system.

`format_resource_list` is deleted.

## Checked elsewhere

Other resource listings were already one per line, going through `format_resources_styled`:

- reservation created / updated / deleted notices
- conflict messages
- unauthorized-usage DM

`join(", ")` remains in log lines and a test mock, where a single line is what you want.

## Test plan

- [x] `the_message_lists_each_resource_on_its_own_line` pins the layout and the shared spelling
- [x] `cargo test --workspace --all-features` — 138 passed
- [x] `cargo clippy --workspace --all-targets --all-features -- -Dwarnings` — clean
- [x] `cargo fmt --all --check`
- [ ] Not seen in Slack yet. Visible on the next unreserved usage after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KHaZgaoJcQjDGXZF9PJ9S