### PR TITLE
fix: report conflicts per reservation instead of per resource

### DIFF
--- a/src/application/error.rs
+++ b/src/application/error.rs
@@ -78,7 +78,11 @@ impl fmt::Display for ApplicationError {
                     .map(|c| {
                         format!(
                             "リソース {} は既に使用予定 {} で使用されています",
-                            c.resource,
+                            c.resources
+                                .iter()
+                                .map(|resource| resource.to_string())
+                                .collect::<Vec<_>>()
+                                .join(", "),
                             c.existing_usage.id().as_str()
                         )
                     })

--- a/src/domain/services/resource_usage/conflict_checker.rs
+++ b/src/domain/services/resource_usage/conflict_checker.rs
@@ -1,6 +1,7 @@
 use crate::domain::aggregates::resource_usage::value_objects::{Resource, TimePeriod, UsageId};
 use crate::domain::ports::repositories::ResourceUsageRepository;
 use crate::domain::services::resource_usage::errors::{ConflictCheckError, ResourceConflictError};
+use std::collections::HashMap;
 
 /// リソース競合チェックサービス
 ///
@@ -31,8 +32,12 @@ impl ResourceConflictChecker {
     ///
     /// # Returns
     /// 競合がない場合はOk(())、競合がある場合はエラー。
-    /// 複数リソースを同時にリクエストした場合、競合したリソースが複数あれば
-    /// その全件をまとめて返す（最初の1件で打ち切らない）。
+    ///
+    /// 競合は既存予約ごとに1件へまとめ、その予約と重なったリソースを併せて返す。
+    /// 打ち切りは行わない。複数のリソースが競合していれば全件を、ひとつのリソースが
+    /// 複数の予約と競合していれば（既存の予約同士が重複している場合に起こりうる）
+    /// その全ての予約を返す。時間をずらせば解決するのか、他にも障害があるのかを
+    /// 呼び出し側が判断できる必要がある。
     ///
     /// # Errors
     /// - 競合するリソースがある場合
@@ -47,8 +52,11 @@ impl ResourceConflictChecker {
         // 指定期間と重複する予約を検索
         let overlapping = repository.find_overlapping(time_period).await?;
 
-        // リソースごとに競合をチェックし、全件収集する
-        let mut conflicts = Vec::new();
+        // 競合は既存予約ごとに1件へまとめる。ひとつの予約が複数のリソースを押さえている
+        // 場合、リソースごとに分けて返すと受け取った側がまとめ直すことになる。
+        // 検出した順序を保つため、予約IDから収集先の位置を引く。
+        let mut conflicts: Vec<ResourceConflictError> = Vec::new();
+        let mut position_of: HashMap<UsageId, usize> = HashMap::new();
 
         for new_resource in resources {
             for existing_usage in &overlapping {
@@ -65,11 +73,18 @@ impl ResourceConflictChecker {
                     .any(|existing_resource| new_resource.conflicts_with(existing_resource));
 
                 if conflicts_with_this_usage {
-                    conflicts.push(ResourceConflictError::new(
-                        new_resource.clone(),
-                        existing_usage.clone(),
-                    ));
-                    break;
+                    match position_of.get(existing_usage.id()) {
+                        Some(&position) => {
+                            conflicts[position].resources.push(new_resource.clone());
+                        }
+                        None => {
+                            position_of.insert(existing_usage.id().clone(), conflicts.len());
+                            conflicts.push(ResourceConflictError::new(
+                                vec![new_resource.clone()],
+                                existing_usage.clone(),
+                            ));
+                        }
+                    }
                 }
             }
         }
@@ -219,5 +234,80 @@ mod tests {
             .await;
 
         assert!(result.is_ok());
+    }
+    #[tokio::test]
+    async fn conflicts_with_one_reservation_are_reported_as_a_single_entry() {
+        // ひとつの予約が3枚を押さえていて、その3枚をまとめて予約しようとする
+        let existing = usage_with(
+            "alice@example.com",
+            vec![
+                Resource::Gpu(Gpu::new("Thalys".to_string(), 0, "A100".to_string())),
+                Resource::Gpu(Gpu::new("Thalys".to_string(), 1, "A100".to_string())),
+                Resource::Gpu(Gpu::new("Thalys".to_string(), 2, "A100".to_string())),
+            ],
+        );
+        let repository = StubRepository {
+            overlapping: vec![existing],
+        };
+
+        let requested = vec![
+            Resource::Gpu(Gpu::new("Thalys".to_string(), 0, "A100".to_string())),
+            Resource::Gpu(Gpu::new("Thalys".to_string(), 1, "A100".to_string())),
+            Resource::Gpu(Gpu::new("Thalys".to_string(), 2, "A100".to_string())),
+        ];
+
+        let checker = ResourceConflictChecker::new();
+        let result = checker
+            .check_conflicts(&repository, &test_period(), &requested, None)
+            .await;
+
+        let Err(ConflictCheckError::Conflict(conflicts)) = result else {
+            panic!("expected Conflict, got {result:?}");
+        };
+
+        assert_eq!(
+            conflicts.len(),
+            1,
+            "同じ予約との競合は1件にまとめるべき（受け取った側がまとめ直さずに済むように）"
+        );
+        assert_eq!(
+            conflicts[0].resources.len(),
+            3,
+            "競合した全リソースを持つべき"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_resource_conflicting_with_several_reservations_reports_all_of_them() {
+        // 既存の予約同士が重複している状況（同じGPUを2件が押さえている）
+        let gpu0 = || Resource::Gpu(Gpu::new("Thalys".to_string(), 0, "A100".to_string()));
+        let repository = StubRepository {
+            overlapping: vec![
+                usage_with("alice@example.com", vec![gpu0()]),
+                usage_with("bob@example.com", vec![gpu0()]),
+            ],
+        };
+
+        let checker = ResourceConflictChecker::new();
+        let result = checker
+            .check_conflicts(&repository, &test_period(), &[gpu0()], None)
+            .await;
+
+        let Err(ConflictCheckError::Conflict(conflicts)) = result else {
+            panic!("expected Conflict, got {result:?}");
+        };
+
+        // 片方だけ知らせると、時間をずらしてもまた失敗する
+        assert_eq!(
+            conflicts.len(),
+            2,
+            "ひとつのリソースが複数の予約と競合するなら、その全てを知らせるべき"
+        );
+        let owners: Vec<&str> = conflicts
+            .iter()
+            .map(|c| c.existing_usage.owner_email().as_str())
+            .collect();
+        assert!(owners.contains(&"alice@example.com"));
+        assert!(owners.contains(&"bob@example.com"));
     }
 }

--- a/src/domain/services/resource_usage/errors.rs
+++ b/src/domain/services/resource_usage/errors.rs
@@ -8,21 +8,24 @@ use std::fmt;
 
 /// リソース競合エラー（リクエストしたリソース1件分）
 ///
-/// 競合したリソースと既存の使用予定そのものを保持する。
+/// ひとつの既存予約に対して1件で表す。予約は複数のリソースを押さえうるため、
+/// その予約と競合したリソースをまとめて保持する。リソースごとに分けて返すと、
+/// 受け取った側が予約単位へまとめ直す必要が生じる。
+///
 /// メッセージ文言はインターフェース層が設定に基づいて組み立てられるよう、
 /// ここでは構造化データのまま渡す。
 #[derive(Debug)]
 pub struct ResourceConflictError {
-    /// 競合しているリソース
-    pub resource: Resource,
+    /// この予約と競合したリソース
+    pub resources: Vec<Resource>,
     /// 競合している既存の使用予定
     pub existing_usage: ResourceUsage,
 }
 
 impl ResourceConflictError {
-    pub fn new(resource: Resource, existing_usage: ResourceUsage) -> Self {
+    pub fn new(resources: Vec<Resource>, existing_usage: ResourceUsage) -> Self {
         Self {
-            resource,
+            resources,
             existing_usage,
         }
     }
@@ -30,10 +33,16 @@ impl ResourceConflictError {
 
 impl fmt::Display for ResourceConflictError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let resources = self
+            .resources
+            .iter()
+            .map(|resource| resource.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
         write!(
             f,
             "リソース競合: {} (競合する予約ID: {})",
-            self.resource,
+            resources,
             self.existing_usage.id().as_str()
         )
     }

--- a/src/infrastructure/notifier/template_renderer.rs
+++ b/src/infrastructure/notifier/template_renderer.rs
@@ -111,7 +111,7 @@ impl<'a> TemplateRenderer<'a> {
     /// `conflicting_resource`は競合したリソース単体（要求リソースのうち衝突した1件）。
     pub fn render_conflict(
         &self,
-        conflicting_resource: &Resource,
+        conflicting_resources: &[Resource],
         existing_usage: &ResourceUsage,
         user_display: &str,
     ) -> String {
@@ -122,7 +122,7 @@ impl<'a> TemplateRenderer<'a> {
             .unwrap_or(defaults::CONFLICT);
         self.render(
             template,
-            std::slice::from_ref(conflicting_resource),
+            conflicting_resources,
             existing_usage.time_period(),
             existing_usage.notes().map(String::as_str),
             user_display,
@@ -355,7 +355,11 @@ mod tests {
         let conflicting_resource =
             Resource::Gpu(Gpu::new("Thalys".to_string(), 0, "A100".to_string()));
 
-        let result = renderer.render_conflict(&conflicting_resource, &existing_usage, "<@U67890>");
+        let result = renderer.render_conflict(
+            std::slice::from_ref(&conflicting_resource),
+            &existing_usage,
+            "<@U67890>",
+        );
 
         assert!(result.contains("⚠️ 予約が重複しています"));
         assert!(result.contains("<@U67890>"));
@@ -379,7 +383,11 @@ mod tests {
         let conflicting_resource =
             Resource::Gpu(Gpu::new("Thalys".to_string(), 1, "A100".to_string()));
 
-        let result = renderer.render_conflict(&conflicting_resource, &existing_usage, "田中太郎");
+        let result = renderer.render_conflict(
+            std::slice::from_ref(&conflicting_resource),
+            &existing_usage,
+            "田中太郎",
+        );
 
         assert!(result.contains("田中太郎が既に"));
         assert!(result.contains("GPU:1"));

--- a/src/interface/slack/utility/conflict_message.rs
+++ b/src/interface/slack/utility/conflict_message.rs
@@ -46,9 +46,13 @@ async fn build_one(
         user_resolver::resolve_display_name(conflict.existing_usage.owner_email(), identity_repo)
             .await;
 
-    // 競合先リソースに紐づく通知設定を流用し、テンプレート/フォーマットを一致させる
-    let notification_config = resource_config
-        .get_notifications_for_resource(&conflict.resource)
+    // 競合先リソースに紐づく通知設定を流用し、テンプレート/フォーマットを一致させる。
+    // まとめた競合は同一予約に属するため、どのリソースを見ても同じ設定になる。
+    let notification_config = conflict
+        .resources
+        .first()
+        .map(|resource| resource_config.get_notifications_for_resource(resource))
+        .unwrap_or_default()
         .into_iter()
         .next();
 
@@ -67,5 +71,129 @@ async fn build_one(
         timezone_owned.as_deref(),
     );
 
-    renderer.render_conflict(&conflict.resource, &conflict.existing_usage, &owner_display)
+    renderer.render_conflict(
+        &conflict.resources,
+        &conflict.existing_usage,
+        &owner_display,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::aggregates::identity_link::entity::IdentityLink;
+    use crate::domain::aggregates::identity_link::value_objects::ExternalSystem;
+    use crate::domain::aggregates::resource_usage::entity::ResourceUsage;
+    use crate::domain::aggregates::resource_usage::value_objects::{Gpu, Resource, TimePeriod};
+    use crate::domain::common::EmailAddress;
+    use crate::domain::ports::repositories::RepositoryError;
+    use crate::infrastructure::config::{DeviceConfig, ServerConfig};
+    use async_trait::async_trait;
+    use chrono::{Duration, Utc};
+
+    /// 表示名を解決しないテスト用リポジトリ（メールアドレスがそのまま表示される）
+    struct NoLinks;
+
+    #[async_trait]
+    impl IdentityLinkRepository for NoLinks {
+        async fn find_by_email(
+            &self,
+            _email: &EmailAddress,
+        ) -> Result<Option<IdentityLink>, RepositoryError> {
+            Ok(None)
+        }
+
+        async fn find_by_external_user_id(
+            &self,
+            _system: &ExternalSystem,
+            _user_id: &str,
+        ) -> Result<Option<IdentityLink>, RepositoryError> {
+            unimplemented!("このテストでは使用しない")
+        }
+
+        async fn save(&self, _identity_link: IdentityLink) -> Result<(), RepositoryError> {
+            unimplemented!("このテストでは使用しない")
+        }
+    }
+
+    fn gpu(device_number: u32) -> Resource {
+        Resource::Gpu(Gpu::new(
+            "Thalys".to_string(),
+            device_number,
+            "A100 80GB PCIe".to_string(),
+        ))
+    }
+
+    fn config() -> ResourceConfig {
+        ResourceConfig {
+            servers: vec![ServerConfig {
+                name: "Thalys".to_string(),
+                calendar_id: "cal".to_string(),
+                devices: (0..4)
+                    .map(|id| DeviceConfig {
+                        id,
+                        model: "A100 80GB PCIe".to_string(),
+                    })
+                    .collect(),
+                notifications: vec![],
+            }],
+            rooms: vec![],
+        }
+    }
+
+    fn reservation(owner: &str, resources: Vec<Resource>) -> ResourceUsage {
+        let now = Utc::now();
+        ResourceUsage::new(
+            EmailAddress::new(owner.to_string()).unwrap(),
+            TimePeriod::new(now, now + Duration::hours(2)).unwrap(),
+            resources,
+            None,
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn conflicts_with_one_reservation_are_reported_as_one_message() {
+        let existing = reservation("owner@example.com", vec![gpu(0), gpu(1), gpu(2)]);
+        let conflicts = vec![ResourceConflictError::new(
+            vec![gpu(0), gpu(1), gpu(2)],
+            existing,
+        )];
+        let repo: Arc<dyn IdentityLinkRepository> = Arc::new(NoLinks);
+
+        let message = build(&conflicts, &config(), &repo).await;
+
+        assert_eq!(
+            message.matches("予約が重複しています").count(),
+            1,
+            "同じ予約との競合は1つのメッセージにまとめるべき: {message}"
+        );
+        for device in ["GPU:0", "GPU:1", "GPU:2"] {
+            assert!(
+                message.contains(device),
+                "競合した全リソースを載せるべき ({device}): {message}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn conflicts_with_separate_reservations_are_reported_separately() {
+        let first = reservation("owner-a@example.com", vec![gpu(0)]);
+        let second = reservation("owner-b@example.com", vec![gpu(1)]);
+        let conflicts = vec![
+            ResourceConflictError::new(vec![gpu(0)], first),
+            ResourceConflictError::new(vec![gpu(1)], second),
+        ];
+        let repo: Arc<dyn IdentityLinkRepository> = Arc::new(NoLinks);
+
+        let message = build(&conflicts, &config(), &repo).await;
+
+        assert_eq!(
+            message.matches("予約が重複しています").count(),
+            2,
+            "予約が別なら、予約者ごとに分けて伝えるべき: {message}"
+        );
+        assert!(message.contains("owner-a@example.com"));
+        assert!(message.contains("owner-b@example.com"));
+    }
 }


### PR DESCRIPTION
## Why

Reserving three GPUs that clash with one existing booking produced this:

```
⚠️ 予約が重複しています
👤 予約者  <@U01ABCDEF>
📅 競合する期間  2026-07-28 19:00 - 21:00
💻 リソース  Thalys / A100 80GB PCIe / GPU:0

⚠️ 予約が重複しています
👤 予約者  <@U01ABCDEF>
📅 競合する期間  2026-07-28 19:00 - 21:00
💻 リソース  Thalys / A100 80GB PCIe / GPU:1

⚠️ 予約が重複しています
👤 予約者  <@U01ABCDEF>
📅 競合する期間  2026-07-28 19:00 - 21:00
💻 リソース  Thalys / A100 80GB PCIe / GPU:2
```

The same reserver and period repeated three times, differing only in the GPU number.

## The pattern behind it

This is the **third** place needing the same regrouping:

| | |
|---|---|
| #104 | proposals grouped observations per occasion |
| #123 | unauthorized-usage notices grouped observations per reservation |
| this | conflicts grouped per reservation |

Writing that grouping a third time was the signal. A reservation holds several resources, but the checker reported at **resource** granularity, so every layer that thinks in reservations had to reassemble. Fixing it in the message layer would have left the fourth caller to rediscover the same thing.

So the grouping moves to where the data is produced:

```rust
pub struct ResourceConflictError {
    pub resources: Vec<Resource>,   // resources of ours that clash with this booking
    pub existing_usage: ResourceUsage,
}
```

The message layer now has no grouping logic.

## Second defect found while here

The search **stopped at the first overlapping reservation** for each resource:

```rust
if conflicts_with_this_usage {
    conflicts.push(…);
    break;          // ← only the first booking is reported
}
```

A resource can clash with more than one booking when existing reservations overlap each other — which they did, eight times in these calendars. Reporting only one means the user reschedules to avoid it and **fails again on the second**.

The doc comment already claimed "最初の1件で打ち切らない", but that applied to resources only. Now neither is truncated.

## Result

```
⚠️ 予約が重複しています
👤 予約者  <@U01ABCDEF>
📅 競合する期間  2026-07-28 19:00 - 21:00
💻 リソース
Thalys / A100 80GB PCIe / GPU:0
Thalys / A100 80GB PCIe / GPU:1
Thalys / A100 80GB PCIe / GPU:2
```

## Test plan

- [x] `conflicts_with_one_reservation_are_reported_as_a_single_entry` — three clashing GPUs of one booking give one entry holding all three
- [x] `a_resource_conflicting_with_several_reservations_reports_all_of_them` — with two overlapping existing bookings, both are reported, not just the first
- [x] `conflicts_with_one_reservation_are_reported_as_one_message` — the rendered message says 予約が重複しています once and lists every resource
- [x] `conflicts_with_separate_reservations_are_reported_separately` — guards against over-grouping; different reservers stay separate messages
- [x] `cargo test --workspace --all-features` — 141 passed
- [x] `cargo clippy --workspace --all-targets --all-features -- -Dwarnings` — clean
- [x] `cargo fmt --all --check`

Stacks conceptually on #124 (proposal DM formatting) but touches different files; both are independent of each other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KHaZgaoJcQjDGXZF9PJ9S