### PR TITLE
fix: name the conflicting reservation's owner when acceptance fails

### DIFF
--- a/src/interface/slack/block_actions/accept_proposal_button.rs
+++ b/src/interface/slack/block_actions/accept_proposal_button.rs
@@ -1,11 +1,14 @@
 //! 事後予約提案の受諾ボタンハンドラ
 
+use crate::application::error::ApplicationError;
 use crate::domain::aggregates::resource_usage::value_objects::{Gpu, Resource};
 use crate::domain::common::EmailAddress;
 use crate::domain::ports::notifier::Notifier;
 use crate::domain::ports::repositories::ResourceUsageRepository;
+use crate::domain::services::resource_usage::errors::ResourceConflictError;
 use crate::infrastructure::reservation_proposal::ProposalAcceptPayload;
 use crate::interface::slack::app::SlackApp;
+use crate::interface::slack::utility::conflict_message;
 use chrono::Duration;
 use slack_morphism::prelude::*;
 use tracing::{error, info, warn};
@@ -33,9 +36,9 @@ where
     let outcome = create_reservation_from_payload(app, value).await;
     let feedback = match &outcome {
         Ok(_) => "✅ 予約を作成しました".to_string(),
-        Err(e) => {
-            error!(error = %e, "settling the proposed reservation failed");
-            format!("❌ 予約の作成に失敗しました: {}", e)
+        Err(failure) => {
+            error!(error = %failure, "settling the proposed reservation failed");
+            build_failure_message(app, failure).await
         }
     };
 
@@ -81,6 +84,83 @@ where
     Ok(())
 }
 
+/// 受諾を完了できなかった理由
+///
+/// ユースケースまで届いたかどうかで扱いが変わる。届いたなら`ApplicationError`をそのまま
+/// 持ち、`/reserve`や`/update`と同じように競合を型で判別できる。
+enum AcceptFailure {
+    /// ユースケースが予約を作れなかった
+    ///
+    /// 受諾者を併せて持つのは、競合の相手が本人かどうかを利用者に伝えるためである。
+    Rejected {
+        accepted_by: EmailAddress,
+        error: ApplicationError,
+    },
+    /// ボタンのペイロードやリソース設定を解釈できず、ユースケースまで届かなかった
+    Unprocessable(Box<dyn std::error::Error + Send + Sync>),
+}
+
+impl std::fmt::Display for AcceptFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Rejected { error, .. } => write!(f, "{}", error),
+            Self::Unprocessable(error) => write!(f, "{}", error),
+        }
+    }
+}
+
+impl<E> From<E> for AcceptFailure
+where
+    E: Into<Box<dyn std::error::Error + Send + Sync>>,
+{
+    fn from(error: E) -> Self {
+        Self::Unprocessable(error.into())
+    }
+}
+
+/// 競合の相手がすべて受諾者本人か
+///
+/// 本人の予約と重なっているだけなら、その時間帯は既に確保できている。
+/// 利用者に取れる行動がないので、失敗ではなくその旨を伝える。
+fn conflicts_only_with_own_reservations(
+    conflicts: &[ResourceConflictError],
+    accepted_by: &EmailAddress,
+) -> bool {
+    conflicts
+        .iter()
+        .all(|conflict| conflict.existing_usage.owner_email() == accepted_by)
+}
+
+/// 受諾できなかった理由を利用者に伝える文面を組み立てる
+///
+/// 競合の場合、誰の予約と重なったのかが分からなければ利用者は動きようがない。
+/// `/reserve`と同じ整形を通し、相手が本人であれば予約しなくてよいことを伝える。
+async fn build_failure_message<R, N>(app: &SlackApp<R, N>, failure: &AcceptFailure) -> String
+where
+    R: ResourceUsageRepository + Send + Sync + 'static,
+    N: Notifier + Send + Sync + 'static,
+{
+    let AcceptFailure::Rejected {
+        accepted_by,
+        error: ApplicationError::ResourceConflict { conflicts },
+    } = failure
+    else {
+        return format!("❌ 予約の作成に失敗しました: {}", failure);
+    };
+
+    let detail =
+        conflict_message::build(conflicts, app.resource_config(), app.identity_repo()).await;
+
+    if conflicts_only_with_own_reservations(conflicts, accepted_by) {
+        format!(
+            "ℹ️ すでにご自身の予約があるため、事後予約は作成しませんでした\n\nこの時間帯は確保済みです。あらためて予約する必要はありません。\n\n{}",
+            detail
+        )
+    } else {
+        format!("❌ 予約を作成できませんでした\n\n{}", detail)
+    }
+}
+
 /// 提案メッセージ（ボタンが乗っているメッセージ）の位置
 fn proposal_message_ref(
     block_actions: &SlackInteractionBlockActionsEvent,
@@ -109,7 +189,7 @@ fn dm_channel_id(block_actions: &SlackInteractionBlockActionsEvent) -> Option<Sl
 async fn create_reservation_from_payload<R, N>(
     app: &SlackApp<R, N>,
     value: &str,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+) -> Result<(), AcceptFailure>
 where
     R: ResourceUsageRepository + Send + Sync + 'static,
     N: Notifier + Send + Sync + 'static,
@@ -126,12 +206,16 @@ where
 
     app.accept_reservation_proposal_usecase()
         .execute(
-            owner_email,
+            owner_email.clone(),
             resources,
             payload.active_since,
             Duration::minutes(payload.duration_minutes),
         )
-        .await?;
+        .await
+        .map_err(|error| AcceptFailure::Rejected {
+            accepted_by: owner_email,
+            error,
+        })?;
 
     Ok(())
 }
@@ -171,4 +255,77 @@ where
             )))
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::aggregates::resource_usage::entity::ResourceUsage;
+    use crate::domain::aggregates::resource_usage::value_objects::TimePeriod;
+    use crate::domain::services::resource_usage::errors::ResourceConflictError;
+    use chrono::Utc;
+
+    fn gpu(device_number: u32) -> Resource {
+        Resource::Gpu(Gpu::new(
+            "gpu-server-1".to_string(),
+            device_number,
+            "A100 80GB PCIe".to_string(),
+        ))
+    }
+
+    fn conflict_with(owner: &str, device_number: u32) -> ResourceConflictError {
+        let now = Utc::now();
+        let existing_usage = ResourceUsage::new(
+            EmailAddress::new(owner.to_string()).unwrap(),
+            TimePeriod::new(now, now + Duration::hours(2)).unwrap(),
+            vec![gpu(device_number)],
+            None,
+        )
+        .unwrap();
+
+        ResourceConflictError {
+            resources: vec![gpu(device_number)],
+            existing_usage,
+        }
+    }
+
+    fn accepter() -> EmailAddress {
+        EmailAddress::new("member@example.com".to_string()).unwrap()
+    }
+
+    #[test]
+    fn a_conflict_with_ones_own_reservation_is_recognised_as_such() {
+        let conflicts = vec![
+            conflict_with("member@example.com", 0),
+            conflict_with("member@example.com", 1),
+        ];
+
+        assert!(conflicts_only_with_own_reservations(
+            &conflicts,
+            &accepter()
+        ));
+    }
+
+    #[test]
+    fn a_conflict_with_someone_else_is_not_ones_own() {
+        let conflicts = vec![conflict_with("colleague@example.com", 0)];
+
+        assert!(!conflicts_only_with_own_reservations(
+            &conflicts,
+            &accepter()
+        ));
+    }
+
+    #[test]
+    fn conflicting_with_both_oneself_and_someone_else_is_not_ones_own() {
+        let conflicts = vec![
+            conflict_with("member@example.com", 0),
+            conflict_with("colleague@example.com", 1),
+        ];
+
+        assert!(!conflicts_only_with_own_reservations(
+            &conflicts,
+            &accepter()
+        ));
+    }
 }


### PR DESCRIPTION
Stacked on #128.

## Why

A member reported that pressing the accept button on an unauthorized-usage notice was refused, and they could not tell why. What they saw:

```text
❌ 予約の作成に失敗しました: リソース Lyria GPU#0 (Quadro RTX 8000) は既に使用予定 4746890e-… で使用されています
```

The reservation it conflicted with was **their own**. Nothing in the message says so — a reservation id is not something a member can look up — so the sensible reading is "someone else took it" and the correct action ("nothing, you already hold it") is invisible.

`/reserve` and `/update` already answer this. Both match on `ApplicationError::ResourceConflict` and route through `conflict_message::build`, which names the owner as a Slack mention. Only the accept button emitted the raw error.

## What

The accept path uses the same formatter, and states the "it is yours" case outright:

```text
ℹ️ すでにご自身の予約があるため、事後予約は作成しませんでした

この時間帯は確保済みです。あらためて予約する必要はありません。

⚠️ 予約が重複しています
👤 予約者
<@U…>
📅 競合する期間
2026-07-22 18:26 - 2026-07-23 18:26 (Asia/Tokyo)
💻 リソース
Lyria / Quadro RTX 8000 / GPU:0
```

When the conflict is with someone else, the header is `❌ 予約を作成できませんでした` and the same detail follows — a mention the member can go and talk to.

## How

The three conflict paths had inconsistent interfaces. `create_reservation_from_payload` collapsed everything into `Box<dyn Error + Send + Sync>`, so recovering the conflict meant `downcast_ref::<ApplicationError>()` — throwing the type away and then guessing it back.

`AcceptFailure` keeps it instead:

```rust
enum AcceptFailure {
    Rejected { accepted_by: EmailAddress, error: ApplicationError },
    Unprocessable(Box<dyn std::error::Error + Send + Sync>),
}
```

The split is meaningful on its own: a malformed payload and a rejected booking are different events, and only the second one has an accepter to compare against. `Rejected` carries that accepter, which is what makes the ownership check possible without re-parsing the button payload. `From<E>` keeps `?` working for the payload-side errors.

## Test plan

`build_failure_message` needs a whole `SlackApp` (Slack client, tokens, every usecase), which no test constructs. The decision it makes does not, so it is its own function — three tests written to fail first:

- [x] `a_conflict_with_ones_own_reservation_is_recognised_as_such`
- [x] `a_conflict_with_someone_else_is_not_ones_own`
- [x] `conflicting_with_both_oneself_and_someone_else_is_not_ones_own` — a partial overlap is not "yours"; telling a member no action is needed there would be wrong

The formatting itself is already covered by `conflict_message`'s tests.

- [x] `cargo test --workspace --all-features` — 147 passed
- [x] `cargo clippy --workspace --all-targets --all-features -- -Dwarnings` — clean
- [x] `cargo build` with `RUSTFLAGS=-D warnings` — clean
- [x] `cargo fmt --all --check`
- [ ] Not yet seen on the live service. Worth confirming after deploy that the own-reservation branch is the one that fires — it is the case the report came from

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KHaZgaoJcQjDGXZF9PJ9S
