### PR TITLE
fix: convert the log messages that #121 left behind

### DIFF
--- a/src/application/usecases/reconcile_observed_usages.rs
+++ b/src/application/usecases/reconcile_observed_usages.rs
@@ -300,14 +300,14 @@ where
         }
 
         info!(
-            "📨 事後予約を提案: owner={}, resources=[{}], active_since={}",
-            owner_email.as_str(),
-            resources
+            owner = %owner_email.as_str(),
+            resources = %resources
                 .iter()
                 .map(|resource| resource.to_string())
                 .collect::<Vec<_>>()
                 .join(", "),
-            first.active_since()
+            active_since = %first.active_since(),
+            "proposing a post-hoc reservation"
         );
 
         let proposal = ReservationProposal::new(

--- a/src/infrastructure/repositories/resource_usage/google_calendar/repository.rs
+++ b/src/infrastructure/repositories/resource_usage/google_calendar/repository.rs
@@ -188,8 +188,9 @@ impl GoogleCalendarUsageRepository {
             .await
             .inspect_err(|e| {
                 tracing::warn!(
-                    "予約者の紐付け取得に失敗しました（OS名は省略します）: {}",
-                    e
+                    owner = %usage.owner_email().as_str(),
+                    error = %e,
+                    "looking up the reserver's identity link failed; omitting the os user name"
                 )
             })
             .ok()
@@ -268,15 +269,15 @@ impl GoogleCalendarUsageRepository {
                     Err(e) => {
                         if self.should_report_parse_failure(&event_id) {
                             tracing::warn!(
-                                "イベントを予約として解釈できませんでした: calendar_id={}, event_id={}, error={}",
-                                calendar_id,
-                                event_id,
-                                e
+                                calendar_id = %calendar_id,
+                                event_id = %event_id,
+                                error = %e,
+                                "the event is not a reservation; skipping it"
                             );
                         } else {
                             tracing::debug!(
-                                "イベントを予約として解釈できませんでした(既報): event_id={}",
-                                event_id
+                                event_id = %event_id,
+                                "the event is not a reservation; skipping it (already reported)"
                             );
                         }
                         None
@@ -705,18 +706,18 @@ impl GoogleCalendarUsageRepository {
             match self.gateway.delete_event(&calendar_id, event_id).await {
                 Ok(_) => {
                     tracing::info!(
-                        "✅ イベント削除成功: event_id={}, calendar_id={}",
-                        event_id,
-                        calendar_id
+                        event_id = %event_id,
+                        calendar_id = %calendar_id,
+                        "event deleted"
                     );
                     return Ok(());
                 }
                 Err(e) => {
                     tracing::debug!(
-                        "カレンダー {} でイベント {} が見つかりませんでした: {}",
-                        calendar_id,
-                        event_id,
-                        e
+                        calendar_id = %calendar_id,
+                        event_id = %event_id,
+                        error = %e,
+                        "the event is not on this calendar; trying the next one"
                     );
                     // 次のカレンダーを試す
                     continue;
@@ -726,8 +727,8 @@ impl GoogleCalendarUsageRepository {
 
         // すべてのカレンダーで見つからなかった
         tracing::error!(
-            "❌ イベントが全カレンダーで見つかりませんでした: event_id={}",
-            event_id
+            event_id = %event_id,
+            "the event was not found on any calendar"
         );
         Err(RepositoryError::NotFound)
     }

--- a/src/infrastructure/resource_usage_observer/shared_file.rs
+++ b/src/infrastructure/resource_usage_observer/shared_file.rs
@@ -98,9 +98,10 @@ impl SharedFileResourceUsageObserver {
 
         if Utc::now() - report.generated_at > self.max_staleness {
             warn!(
-                "観測ファイルが古いため無視します ({}): generated_at={}",
-                path.display(),
-                report.generated_at
+                path = %path.display(),
+                generated_at = %report.generated_at,
+                max_staleness_secs = self.max_staleness.num_seconds(),
+                "the usage report is too old; ignoring it"
             );
             return Vec::new();
         }
@@ -111,8 +112,8 @@ impl SharedFileResourceUsageObserver {
     fn build_observed_usages(&self, report: &GpuUsageReport) -> Vec<ObservedUsage> {
         let Some(server_config) = self.resource_config.get_server(&report.server) else {
             warn!(
-                "未設定のサーバーからの観測データを無視します: {}",
-                report.server
+                server = %report.server,
+                "the usage report is for a server that is not configured; ignoring it"
             );
             return Vec::new();
         };

--- a/src/interface/slack/block_actions/accept_proposal_button.rs
+++ b/src/interface/slack/block_actions/accept_proposal_button.rs
@@ -197,8 +197,11 @@ where
     let payload: ProposalAcceptPayload = serde_json::from_str(value)?;
 
     info!(
-        "📍 事後予約作成: server={}, devices={:?}, owner={}, duration_minutes={}",
-        payload.server, payload.device_numbers, payload.owner_email, payload.duration_minutes
+        server = %payload.server,
+        devices = ?payload.device_numbers,
+        owner = %payload.owner_email,
+        duration_minutes = payload.duration_minutes,
+        "accepting a post-hoc reservation proposal"
     );
 
     let resources = resolve_gpu_resources(app, &payload.server, &payload.device_numbers)?;

--- a/src/interface/slack/block_actions/cancel_button.rs
+++ b/src/interface/slack/block_actions/cancel_button.rs
@@ -64,9 +64,10 @@ where
     // 予約を削除
     let usage_id = UsageId::from_string(usage_id_str.to_string());
     info!(
-        "📍 削除処理開始: usage_id={}, owner={}",
-        usage_id.as_str(),
-        owner_email.as_str()
+        usage_id = %usage_id.as_str(),
+        owner = %owner_email.as_str(),
+        origin = "slack",
+        "cancelling a reservation"
     );
 
     let result = delete_usage_usecase

--- a/src/interface/slack/block_actions/modal_state_change.rs
+++ b/src/interface/slack/block_actions/modal_state_change.rs
@@ -7,7 +7,7 @@ use crate::interface::slack::constants::*;
 use crate::interface::slack::slack_client::modals;
 use crate::interface::slack::views::modals::{link_user, reserve};
 use slack_morphism::prelude::*;
-use tracing::{debug, error, info};
+use tracing::{debug, error};
 
 /// モーダル状態変更を処理（リソースタイプ選択、サーバー選択、リンク対象種別選択）
 ///
@@ -27,10 +27,7 @@ where
     // Get view_id from container
     let view_id = match &block_actions.container {
         SlackInteractionActionContainer::View(view_container) => {
-            info!(
-                "  → view_id取得成功: {}",
-                view_container.view_id.to_string()
-            );
+            debug!(view_id = %view_container.view_id, "resolved the modal to update");
             view_container.view_id.clone()
         }
         SlackInteractionActionContainer::Message(_)
@@ -52,10 +49,7 @@ where
     debug!("requesting a modal update");
     modals::update(app.slack_client(), app.bot_token(), &view_id, updated_modal).await?;
 
-    info!(
-        "✅ モーダルを動的に更新しました (view_id: {})",
-        view_id.to_string()
-    );
+    debug!(view_id = %view_id, "modal updated");
 
     Ok(())
 }
@@ -93,9 +87,10 @@ where
         None
     };
 
-    info!(
-        "📝 選択値: type={:?}, server={:?}",
-        new_resource_type, new_selected_server
+    debug!(
+        resource_type = ?new_resource_type,
+        server = ?new_selected_server,
+        "rebuilding the reservation modal from the current selection"
     );
 
     reserve::create_reserve_modal(

--- a/src/interface/slack/slash_commands/reserve.rs
+++ b/src/interface/slack/slash_commands/reserve.rs
@@ -35,8 +35,8 @@ where
     if !is_linked {
         // Unlinked: Show email registration modal
         info!(
-            "ユーザー {} は未リンク。メールアドレス登録モーダルを表示します",
-            user_id
+            slack_user = %user_id,
+            "the user has no identity link; opening the email registration modal"
         );
 
         let modal = registration::create();
@@ -48,8 +48,8 @@ where
 
     // Linked: Show reservation modal
     info!(
-        "ユーザー {} はリンク済み。予約モーダルを表示します",
-        user_id
+        slack_user = %user_id,
+        "opening the reservation modal"
     );
 
     // Create and open reservation modal

--- a/src/interface/slack/view_submissions/link_user.rs
+++ b/src/interface/slack/view_submissions/link_user.rs
@@ -115,9 +115,9 @@ where
     let message_text = match link_result {
         Ok(_) => {
             info!(
-                "✅ ユーザーリンク成功: {} -> {}",
-                link_target.display,
-                email_result.as_ref().unwrap().as_str()
+                identity = %link_target.display,
+                email = %email_result.as_ref().unwrap().as_str(),
+                "identity linked"
             );
             format!(
                 "✅ ユーザー {} をメールアドレス {} に紐付けました",

--- a/src/interface/slack/view_submissions/registration.rs
+++ b/src/interface/slack/view_submissions/registration.rs
@@ -52,8 +52,8 @@ where
     let message_text = match registration_result {
         Ok(_) => {
             info!(
-                "✅ ユーザー登録成功: {}",
-                email_result.as_ref().unwrap().as_str()
+                email = %email_result.as_ref().unwrap().as_str(),
+                "email address registered"
             );
             format!(
                 "✅ メールアドレス {} を登録しました",


### PR DESCRIPTION
## Why

#121 stated in its test plan that Japanese log messages were down to 0. That was wrong — **17 sites were never converted**, and they are still emitting in v1.6.0. Watching the first poll cycle after deploying it:

```text
INFO reconcile_observed_usages: 📨 事後予約を提案: owner=…, resources=[Lyria GPU#0 …], active_since=2026-07-22 09:26:18 UTC
WARN google_calendar::repository: イベントを予約として解釈できませんでした: calendar_id=…, event_id=…, error=…
```

Both are exactly the shape #121 set out to remove: every value interpolated into the message, so nothing is searchable or countable, and the operator-facing stream mixes two languages.

The `repository.rs` one is not hypothetical — it fires every cycle for three meeting-note events on a shared calendar, and it is the line an operator would reach for when asking "which events is the parser rejecting, and how often". As text it answers neither question without grepping.

The check behind #121's claim only looked at the sites being rewritten, not at the whole tree. It should have been a count over `src/`.

## What changed

17 sites across 9 files, all to fields + English:

```rust
info!(
    owner = %owner_email.as_str(),
    resources = %…,
    active_since = %first.active_since(),
    "proposing a post-hoc reservation"
);
```

Three of them were modal handling at `info` (`  → view_id取得成功`, `✅ モーダルを動的に更新しました`, `📝 選択値`). #121's stated policy is that modal handling belongs at `debug`; these were missed along with the conversion, so they move down too. Levels are now 33 info / 38 debug / 14 warn / 32 error.

Some messages gained a field they never carried. `looking up the reserver's identity link failed` now names the owner, and `the usage report is too old` now records `max_staleness_secs` next to `generated_at` — without it, the line says something was too old but not what the threshold was.

Emoji are gone from the remaining lines for the reason #121 gave: `✅`/`❌` restate the level, and a leading emoji assumes a human at `journalctl` rather than a parser reading fields.

## Not included

No guard against this recurring. A test that scans `src/` for Japanese log messages would have caught it, and is the honest fix for a claim that went unverified — but it is a different kind of change from converting the messages, so it is worth deciding on separately.

## Test plan

- [x] Japanese log messages across `src/`: **17 → 0**, counted by walking every `info!`/`warn!`/`error!`/`debug!`/`trace!` call and inspecting its message literal — the count that should have been run for #121
- [x] Emoji in log messages: **15 → 0**, same walk
- [x] `println!`/`eprintln!` outside test mocks: 0
- [x] `cargo test --workspace --all-features` — 147 passed
- [x] `cargo clippy --workspace --all-targets --all-features -- -Dwarnings` — clean
- [x] `cargo build` with `RUSTFLAGS=-D warnings` — clean
- [x] `cargo fmt --all --check`
- [ ] Not yet observed live. The `reconcile_observed_usages` and `repository.rs` lines both fire every polling cycle, so one cycle after deploy is enough to confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KHaZgaoJcQjDGXZF9PJ9S
