### PR TITLE
fix: replace the proposal blocks so the buttons actually disappear

### DIFF
--- a/src/interface/slack/block_actions/accept_proposal_button.rs
+++ b/src/interface/slack/block_actions/accept_proposal_button.rs
@@ -37,7 +37,7 @@ where
     let feedback = match &outcome {
         Ok(_) => "✅ 予約を作成しました".to_string(),
         Err(failure) => {
-            error!(error = %failure, "settling the proposed reservation failed");
+            log_failure(failure);
             build_failure_message(app, failure).await
         }
     };
@@ -141,6 +141,26 @@ fn conflicts_only_with_own_reservations(
     conflicts
         .iter()
         .all(|conflict| conflict.existing_usage.owner_email() == accepted_by)
+}
+
+/// 受諾できなかった事実を記録する
+///
+/// 競合は利用者の操作から生まれる正常な結果で、運用者に対処できることはない。
+/// `error`に置くと連打のたびに運用者を呼ぶことになるため、`/reserve`と同じくwarnとする。
+/// ユースケースまで届かなかった失敗は運用者が調べる必要があるのでerrorに残す。
+fn log_failure(failure: &AcceptFailure) {
+    match failure {
+        AcceptFailure::Rejected {
+            accepted_by,
+            error: ApplicationError::ResourceConflict { conflicts },
+        } => warn!(
+            owner = %accepted_by.as_str(),
+            conflicts = conflicts.len(),
+            origin = "slack",
+            "reservation rejected: resources already booked"
+        ),
+        _ => error!(error = %failure, "settling the proposed reservation failed"),
+    }
 }
 
 /// 受諾できなかった理由を利用者に伝える文面を組み立てる

--- a/src/interface/slack/block_actions/accept_proposal_button.rs
+++ b/src/interface/slack/block_actions/accept_proposal_button.rs
@@ -51,7 +51,7 @@ where
     {
         let settled = SlackApiChatUpdateRequest::new(
             message_channel,
-            SlackMessageContent::new().with_text(feedback.clone()),
+            settled_message(feedback.clone()),
             message_ts,
         );
         match session.chat_update(&settled).await {
@@ -116,6 +116,18 @@ where
     fn from(error: E) -> Self {
         Self::Unprocessable(error.into())
     }
+}
+
+/// 受諾済みの提案メッセージの中身
+///
+/// `chat.update`は渡さなかったフィールドをそのまま残すため、`text`だけを送っても
+/// 提案時の`blocks`が生き続けてボタンが押せてしまう。結果だけを載せた`blocks`で
+/// 上書きして初めてボタンが消える。
+fn settled_message(feedback: String) -> SlackMessageContent {
+    let block = SlackSectionBlock::new().with_text(md!(feedback.clone()));
+    SlackMessageContent::new()
+        .with_text(feedback)
+        .with_blocks(slack_blocks![some_into(block)])
 }
 
 /// 競合の相手がすべて受諾者本人か
@@ -294,6 +306,30 @@ mod tests {
 
     fn accepter() -> EmailAddress {
         EmailAddress::new("member@example.com".to_string()).unwrap()
+    }
+
+    #[test]
+    fn the_settled_message_carries_blocks_without_any_button() {
+        // chat.updateは渡さなかったフィールドをそのまま残す。textだけを送っても
+        // 提案時のblocksが生き続け、ボタンは消えない。blocksを送り直す必要がある。
+        let content = settled_message("✅ 予約を作成しました".to_string());
+        let json = serde_json::to_value(&content).unwrap();
+
+        let blocks = json["blocks"]
+            .as_array()
+            .expect("blocksを送らないと提案時のボタンが残る");
+        assert!(
+            blocks.iter().all(|block| block["type"] != "actions"),
+            "受諾後のメッセージにボタンが残っている: {:?}",
+            blocks
+        );
+        assert!(
+            serde_json::to_string(&json)
+                .unwrap()
+                .contains("予約を作成しました"),
+            "受諾の結果が本文に出ていない: {:?}",
+            json
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Why

Accepting a proposal is supposed to clear the buttons off the message, so a second press is not offered. It never worked. Reported from Slack: the buttons are still there, and the message is only marked *edited*.

The log said otherwise:

```text
INFO accept_proposal_button: cleared the proposal buttons channel=D0BK3NUJDAB ts=1785235364.960999
```

`chat.update` returned OK, so the handler logged success — but `chat.update` leaves fields you don't send untouched, and we only sent `text`. The proposal's `blocks` survived, buttons included. The text swap is what produced the *edited* marker, which made the whole thing look like it had worked.

This is why button mashing still reaches the usecase. #123 stops it from creating duplicates, but the member gets a wall of conflict messages instead of a message that stops offering the button:

```text
10:47:45  accepting a post-hoc reservation proposal server=Freccia devices=[5]
10:47:48  accepting a post-hoc reservation proposal server=Freccia devices=[5]
10:47:49  settling the proposed reservation failed error=… は既に使用予定 6fb27c48… で使用されています
10:47:49  accepting a post-hoc reservation proposal server=Freccia devices=[5]
10:47:53  settling the proposed reservation failed …
10:47:57  settling the proposed reservation failed …
```

## What

Send `blocks` too, carrying just the outcome:

```rust
fn settled_message(feedback: String) -> SlackMessageContent {
    let block = SlackSectionBlock::new().with_text(md!(feedback.clone()));
    SlackMessageContent::new()
        .with_text(feedback)
        .with_blocks(slack_blocks![some_into(block)])
}
```

`text` stays as the notification fallback. A section block replaces the proposal's blocks outright, so nothing with an `action_id` is left on the message.

## Test plan

Written to fail first — `settled_message` did not exist, and the assertion that fails without it is the one that matters: `blocks` must be present at all.

- [x] `the_settled_message_carries_blocks_without_any_button` — asserts `blocks` is sent, that no block is of type `actions`, and that the outcome text is in the payload

The old shape passes a `text`-only assertion, which is exactly why this went unnoticed; the test is written against the serialized payload for that reason.

- [x] `cargo test --workspace --all-features` — 148 passed
- [x] `cargo clippy --workspace --all-targets --all-features -- -Dwarnings` — clean
- [x] `cargo build` with `RUSTFLAGS=-D warnings` — clean
- [x] `cargo fmt --all --check`
- [ ] Not yet confirmed in Slack. The check after deploy is direct: accept a proposal, and the buttons should be gone rather than the message merely showing *edited*

## Related

Not a fix for the race — a press that lands before the update returns (~3s) still reaches the usecase, where #123's mutex handles it. This removes the button afterwards so there is nothing left to press.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KHaZgaoJcQjDGXZF9PJ9S
