### PR TITLE
feat: end a running reservation now instead of deleting it

### DIFF
--- a/src/application/usecases/mod.rs
+++ b/src/application/usecases/mod.rs
@@ -62,6 +62,8 @@ pub mod notify_future_resource_usage_changes;
 pub mod reconcile_observed_usages;
 #[cfg(test)]
 mod reconcile_observed_usages_tests;
+/// 進行中のリソース使用予定を今の時点で締めるユースケース
+pub mod release_resource_usage_early;
 /// リソース使用予定を更新するユースケース
 pub mod update_resource_usage;
 
@@ -74,4 +76,5 @@ pub use list_all_future_resource_usages::ListAllFutureResourceUsagesUseCase;
 pub use list_user_resource_usages::ListUserResourceUsagesUseCase;
 pub use notify_future_resource_usage_changes::NotifyFutureResourceUsageChangesUseCase;
 pub use reconcile_observed_usages::ReconcileObservedUsagesUseCase;
+pub use release_resource_usage_early::ReleaseResourceUsageEarlyUseCase;
 pub use update_resource_usage::UpdateResourceUsageUseCase;

--- a/src/application/usecases/release_resource_usage_early.rs
+++ b/src/application/usecases/release_resource_usage_early.rs
@@ -1,0 +1,202 @@
+use crate::application::error::ApplicationError;
+use crate::domain::aggregates::resource_usage::entity::ResourceUsage;
+use crate::domain::aggregates::resource_usage::value_objects::UsageId;
+use crate::domain::common::EmailAddress;
+use crate::domain::ports::repositories::{RepositoryError, ResourceUsageRepository};
+use crate::domain::services::{AuthorizationPolicy, ResourceUsageAuthorizationPolicy};
+use chrono::Utc;
+use std::sync::Arc;
+use tracing::info;
+
+/// 進行中の予約を今の時点で締めるユースケース
+///
+/// 取り消しでは「誰がいつ使っていたか」まで消えてしまう。予定より早く使い終わったときに、
+/// 使った分を記録として残したまま残り時間だけを他の利用者へ開くための操作である。
+///
+/// 締める時刻は常に現在時刻とする。任意の終了時刻を指定したい場合は
+/// `UpdateResourceUsageUseCase`が担う。
+pub struct ReleaseResourceUsageEarlyUseCase<R: ResourceUsageRepository> {
+    repository: Arc<R>,
+    authorization_policy: ResourceUsageAuthorizationPolicy,
+}
+
+impl<R: ResourceUsageRepository> ReleaseResourceUsageEarlyUseCase<R> {
+    /// 新しいReleaseResourceUsageEarlyUseCaseインスタンスを作成
+    ///
+    /// # Arguments
+    /// * `repository` - ResourceUsageリポジトリ
+    pub fn new(repository: Arc<R>) -> Self {
+        Self {
+            repository,
+            authorization_policy: ResourceUsageAuthorizationPolicy::new(),
+        }
+    }
+
+    /// 予約を今の時点で締める
+    ///
+    /// # Arguments
+    /// * `id` - 使用予定ID
+    /// * `requested_by` - 操作者のメールアドレス（権限チェック用）
+    ///
+    /// # Returns
+    /// 締めたあとの予約（終了時刻が現在時刻に更新されている）
+    ///
+    /// # Errors
+    /// - 指定されたIDの予約が見つからない場合
+    /// - 所有者が一致しない場合
+    /// - 予約がまだ始まっていない、またはすでに終わっている場合
+    /// - リポジトリエラー
+    pub async fn execute(
+        &self,
+        id: &UsageId,
+        requested_by: &EmailAddress,
+    ) -> Result<ResourceUsage, ApplicationError> {
+        let mut usage = self
+            .repository
+            .find_by_id(id)
+            .await?
+            .ok_or(ApplicationError::Repository(RepositoryError::NotFound))?;
+
+        self.authorization_policy
+            .authorize_update(requested_by, &usage)
+            .map_err(|e| ApplicationError::Unauthorized(e.to_string()))?;
+
+        // 期間を縮める操作のため、新たに占有する時間はなく競合は起こりえない
+        usage.release_early(Utc::now())?;
+
+        self.repository.save(&usage).await?;
+
+        info!(
+            usage_id = %usage.id().as_str(),
+            owner = %usage.owner_email().as_str(),
+            requested_by = %requested_by.as_str(),
+            start = %usage.time_period().start(),
+            end = %usage.time_period().end(),
+            "reservation released early"
+        );
+
+        Ok(usage)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::aggregates::resource_usage::value_objects::{Gpu, Resource, TimePeriod};
+    use crate::infrastructure::repositories::resource_usage::mock::MockUsageRepository;
+    use chrono::{DateTime, Duration};
+
+    fn email(address: &str) -> EmailAddress {
+        EmailAddress::new(address.to_string()).unwrap()
+    }
+
+    fn usage_of(owner: &str, start: DateTime<Utc>, end: DateTime<Utc>) -> ResourceUsage {
+        ResourceUsage::new(
+            email(owner),
+            TimePeriod::new(start, end).unwrap(),
+            vec![Resource::Gpu(Gpu::new(
+                "Thalys".to_string(),
+                0,
+                "A100".to_string(),
+            ))],
+            None,
+        )
+        .unwrap()
+    }
+
+    async fn repository_with(usage: &ResourceUsage) -> Arc<MockUsageRepository> {
+        let repository = Arc::new(MockUsageRepository::new());
+        repository.save(usage).await.unwrap();
+        repository
+    }
+
+    #[tokio::test]
+    async fn the_reservation_ends_now_and_stays_in_the_repository() {
+        let start = Utc::now() - Duration::hours(1);
+        let usage = usage_of("owner@example.com", start, start + Duration::hours(4));
+        let repository = repository_with(&usage).await;
+        let usecase = ReleaseResourceUsageEarlyUseCase::new(repository.clone());
+
+        let released = usecase
+            .execute(usage.id(), &email("owner@example.com"))
+            .await
+            .unwrap();
+
+        assert_eq!(released.time_period().start(), start);
+        assert!(released.time_period().end() < start + Duration::hours(4));
+
+        let stored = repository.find_by_id(usage.id()).await.unwrap();
+        assert_eq!(
+            stored.map(|stored| stored.time_period().end()),
+            Some(released.time_period().end()),
+            "早期終了は予約を消さず、終了時刻の更新として残る"
+        );
+    }
+
+    #[tokio::test]
+    async fn someone_else_cannot_release_a_reservation() {
+        let start = Utc::now() - Duration::hours(1);
+        let usage = usage_of("owner@example.com", start, start + Duration::hours(4));
+        let repository = repository_with(&usage).await;
+        let usecase = ReleaseResourceUsageEarlyUseCase::new(repository.clone());
+
+        let error = usecase
+            .execute(usage.id(), &email("someone@example.com"))
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, ApplicationError::Unauthorized(_)),
+            "所有者以外は締められない: {:?}",
+            error
+        );
+        let stored = repository.find_by_id(usage.id()).await.unwrap().unwrap();
+        assert_eq!(
+            stored.time_period().end(),
+            start + Duration::hours(4),
+            "拒否された操作で予約が変わってはいけない"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_reservation_that_has_not_started_is_rejected() {
+        let start = Utc::now() + Duration::hours(1);
+        let usage = usage_of("owner@example.com", start, start + Duration::hours(2));
+        let repository = repository_with(&usage).await;
+        let usecase = ReleaseResourceUsageEarlyUseCase::new(repository.clone());
+
+        let error = usecase
+            .execute(usage.id(), &email("owner@example.com"))
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, ApplicationError::ResourceUsage(_)),
+            "取り消すべき予約を締めようとした: {:?}",
+            error
+        );
+    }
+
+    #[tokio::test]
+    async fn a_missing_reservation_is_reported_as_not_found() {
+        let repository = Arc::new(MockUsageRepository::new());
+        let usecase = ReleaseResourceUsageEarlyUseCase::new(repository);
+
+        let error = usecase
+            .execute(
+                &UsageId::from_string("unknown".to_string()),
+                &email("owner@example.com"),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                ApplicationError::Repository(RepositoryError::NotFound)
+            ),
+            "存在しない予約: {:?}",
+            error
+        );
+    }
+}

--- a/src/domain/aggregates/resource_usage/entity.rs
+++ b/src/domain/aggregates/resource_usage/entity.rs
@@ -1,6 +1,7 @@
 use super::errors::ResourceUsageError;
 use super::value_objects::*;
 use crate::domain::common::EmailAddress;
+use chrono::{DateTime, Utc};
 
 /// リソース使用予定を表す集約ルート
 ///
@@ -108,5 +109,124 @@ impl ResourceUsage {
     /// 備考を更新する
     pub fn update_notes(&mut self, notes: String) {
         self.notes = Some(notes);
+    }
+
+    /// 予約を`at`の時点で締める（早期終了）
+    ///
+    /// 取り消しが予約そのものを無かったことにするのに対し、早期終了は
+    /// 開始から`at`までを使った事実として残し、残りの時間だけを他の利用者へ開く。
+    ///
+    /// # Errors
+    /// - `at`が開始時刻以前の場合、`ResourceUsageError::NotYetStarted`
+    /// - `at`が終了時刻以降の場合、`ResourceUsageError::AlreadyEnded`
+    pub fn release_early(&mut self, at: DateTime<Utc>) -> Result<(), ResourceUsageError> {
+        if at <= self.time_period.start() {
+            return Err(ResourceUsageError::NotYetStarted {
+                start: self.time_period.start(),
+                at,
+            });
+        }
+        if at >= self.time_period.end() {
+            return Err(ResourceUsageError::AlreadyEnded {
+                end: self.time_period.end(),
+                at,
+            });
+        }
+
+        self.time_period = TimePeriod::new(self.time_period.start(), at)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+
+    fn usage_running_from(start: DateTime<Utc>, end: DateTime<Utc>) -> ResourceUsage {
+        ResourceUsage::new(
+            EmailAddress::new("owner@example.com".to_string()).unwrap(),
+            TimePeriod::new(start, end).unwrap(),
+            vec![Resource::Gpu(Gpu::new(
+                "Thalys".to_string(),
+                0,
+                "A100".to_string(),
+            ))],
+            None,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn releasing_early_shortens_the_reservation_to_that_moment() {
+        let start = Utc::now() - Duration::hours(1);
+        let end = start + Duration::hours(4);
+        let mut usage = usage_running_from(start, end);
+        let now = start + Duration::hours(1);
+
+        usage.release_early(now).unwrap();
+
+        assert_eq!(
+            usage.time_period().start(),
+            start,
+            "使い始めた時刻は実績として残る"
+        );
+        assert_eq!(usage.time_period().end(), now);
+    }
+
+    #[test]
+    fn a_reservation_that_has_not_started_cannot_be_released_early() {
+        let start = Utc::now() + Duration::hours(1);
+        let mut usage = usage_running_from(start, start + Duration::hours(2));
+
+        let error = usage.release_early(Utc::now()).unwrap_err();
+
+        assert!(
+            matches!(error, ResourceUsageError::NotYetStarted { .. }),
+            "使った時間がない予約は締められない（取り消しの領分）: {:?}",
+            error
+        );
+    }
+
+    #[test]
+    fn releasing_exactly_at_the_start_leaves_nothing_to_record() {
+        let start = Utc::now() - Duration::hours(1);
+        let mut usage = usage_running_from(start, start + Duration::hours(2));
+
+        let error = usage.release_early(start).unwrap_err();
+
+        assert!(
+            matches!(error, ResourceUsageError::NotYetStarted { .. }),
+            "長さ0の予約は残せない: {:?}",
+            error
+        );
+    }
+
+    #[test]
+    fn a_reservation_that_has_already_ended_cannot_be_released_early() {
+        let end = Utc::now() - Duration::hours(1);
+        let mut usage = usage_running_from(end - Duration::hours(2), end);
+
+        let error = usage.release_early(Utc::now()).unwrap_err();
+
+        assert!(
+            matches!(error, ResourceUsageError::AlreadyEnded { .. }),
+            "開く残り時間がない: {:?}",
+            error
+        );
+    }
+
+    #[test]
+    fn releasing_early_leaves_the_other_attributes_untouched() {
+        let start = Utc::now() - Duration::hours(1);
+        let mut usage = usage_running_from(start, start + Duration::hours(4));
+        let id = usage.id().clone();
+        let resources = usage.resources().clone();
+
+        usage.release_early(start + Duration::minutes(30)).unwrap();
+
+        assert_eq!(usage.id(), &id, "同じ予約であり続ける");
+        assert_eq!(usage.resources(), &resources);
+        assert_eq!(usage.owner_email().as_str(), "owner@example.com");
     }
 }

--- a/src/domain/aggregates/resource_usage/errors.rs
+++ b/src/domain/aggregates/resource_usage/errors.rs
@@ -13,6 +13,23 @@ pub enum ResourceUsageError {
     },
     /// リソース項目が空
     NoResourceItems,
+    /// まだ始まっていない予約を早期終了しようとした
+    ///
+    /// 使い始める前の予約には使った時間が存在しない。残すべき実績がないため、
+    /// この場合に取れる操作は取り消しである。
+    NotYetStarted {
+        /// 予約の開始時刻
+        start: DateTime<Utc>,
+        /// 早期終了しようとした時刻
+        at: DateTime<Utc>,
+    },
+    /// すでに終わった予約を早期終了しようとした
+    AlreadyEnded {
+        /// 予約の終了時刻
+        end: DateTime<Utc>,
+        /// 早期終了しようとした時刻
+        at: DateTime<Utc>,
+    },
     /// リソース使用の競合
     UsageConflict {
         /// 競合しているリソース名
@@ -35,6 +52,22 @@ impl fmt::Display for ResourceUsageError {
             }
             ResourceUsageError::NoResourceItems => {
                 write!(f, "資源項目エラー: 少なくとも1つの資源項目が必要です")
+            }
+            ResourceUsageError::NotYetStarted { start, at } => {
+                write!(
+                    f,
+                    "まだ始まっていない予約です: 開始時刻({})は指定時刻({})よりあとです。早期終了ではなく取り消してください。",
+                    start.format("%Y-%m-%d %H:%M:%S"),
+                    at.format("%Y-%m-%d %H:%M:%S")
+                )
+            }
+            ResourceUsageError::AlreadyEnded { end, at } => {
+                write!(
+                    f,
+                    "すでに終わった予約です: 終了時刻({})は指定時刻({})より前です。",
+                    end.format("%Y-%m-%d %H:%M:%S"),
+                    at.format("%Y-%m-%d %H:%M:%S")
+                )
             }
             ResourceUsageError::UsageConflict {
                 resource,

--- a/src/domain/aggregates/resource_usage/errors.rs
+++ b/src/domain/aggregates/resource_usage/errors.rs
@@ -56,7 +56,7 @@ impl fmt::Display for ResourceUsageError {
             ResourceUsageError::NotYetStarted { start, at } => {
                 write!(
                     f,
-                    "まだ始まっていない予約です: 開始時刻({})は指定時刻({})よりあとです。早期終了ではなく取り消してください。",
+                    "まだ始まっていない予約です（開始時刻: {}、指定時刻: {}）。早期終了ではなく取り消してください。",
                     start.format("%Y-%m-%d %H:%M:%S"),
                     at.format("%Y-%m-%d %H:%M:%S")
                 )
@@ -64,7 +64,7 @@ impl fmt::Display for ResourceUsageError {
             ResourceUsageError::AlreadyEnded { end, at } => {
                 write!(
                     f,
-                    "すでに終わった予約です: 終了時刻({})は指定時刻({})より前です。",
+                    "すでに終わっている予約です（終了時刻: {}、指定時刻: {}）。",
                     end.format("%Y-%m-%d %H:%M:%S"),
                     at.format("%Y-%m-%d %H:%M:%S")
                 )


### PR DESCRIPTION
Cancelling a reservation erases who held the resource and when, so someone
who finishes early has to choose between losing that record and holding the
resource until the booked end. Releasing early keeps the time actually used
and opens only the remainder.

A reservation that has not started has no time to keep, and one that has
ended has no remainder to open; both are refused so that cancelling stays
the operation for the former.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EP2XesjWRdQ7EKhRmhEcb7

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>