### PR TITLE
refactor: report which servers an observation actually covers

### DIFF
--- a/src/application/usecases/reconcile_observed_usages.rs
+++ b/src/application/usecases/reconcile_observed_usages.rs
@@ -104,7 +104,8 @@ where
     /// 観測・リポジトリアクセス・通知送信に失敗した場合
     pub async fn poll_once(&self) -> Result<(), ApplicationError> {
         let started_at = Utc::now();
-        let observed = self.observer.observe_active_usages().await?;
+        let snapshot = self.observer.observe_active_usages().await?;
+        let observed = snapshot.usages();
         let now = started_at;
         // 突合の相手は「今この瞬間に進行中の予約」だけなので、現在時刻を含む最小の期間を問う
         let in_progress = TimePeriod::new(now, now + Duration::seconds(1))?;
@@ -117,7 +118,7 @@ where
         let mut reserved_by_usage: HashMap<(ExternalIdentity, String), &ObservedUsage> =
             HashMap::new();
 
-        for usage in &observed {
+        for usage in observed {
             match Self::find_active_reservation(&current_usages, usage.resource(), now) {
                 Some(reservation) => {
                     reserved += 1;

--- a/src/domain/ports/mod.rs
+++ b/src/domain/ports/mod.rs
@@ -39,5 +39,7 @@ pub use reservation_proposal::{ReservationProposal, ReservationProposalNotifier}
 pub use resource_collection_access::{
     ResourceCollectionAccessError, ResourceCollectionAccessService,
 };
-pub use resource_usage_observer::{ObservationError, ObservedUsage, ResourceUsageObserver};
+pub use resource_usage_observer::{
+    ObservationError, ObservationSnapshot, ObservedUsage, ResourceUsageObserver,
+};
 pub use unauthorized_usage_notifier::UnauthorizedUsageNotifier;

--- a/src/domain/ports/resource_usage_observer.rs
+++ b/src/domain/ports/resource_usage_observer.rs
@@ -4,6 +4,7 @@ use crate::domain::errors::DomainError;
 use crate::domain::ports::error::PortError;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use std::collections::HashSet;
 use std::fmt;
 
 /// 実サーバー上で観測されたリソース利用の事実
@@ -48,13 +49,57 @@ impl ObservedUsage {
     }
 }
 
+/// 一度の観測で分かったことのまとまり
+///
+/// 「利用が観測されなかった」ことと「そのサーバーを観測できなかった」ことは異なる。
+/// 監視が止まっているサーバーの沈黙を「誰も使っていない」と読むと、実際には
+/// 使われているリソースを空きとみなしてしまう。どのサーバーについて語れるのかを
+/// 利用の一覧と一緒に返し、読み手が両者を区別できるようにする。
+#[derive(Debug, Clone, Default)]
+pub struct ObservationSnapshot {
+    usages: Vec<ObservedUsage>,
+    observed_servers: HashSet<String>,
+}
+
+impl ObservationSnapshot {
+    /// 新しい観測結果を作成
+    ///
+    /// # Arguments
+    /// * `usages` - 観測された利用の一覧
+    /// * `observed_servers` - 利用の有無を把握できたサーバー名の集合
+    pub fn new(usages: Vec<ObservedUsage>, observed_servers: HashSet<String>) -> Self {
+        Self {
+            usages,
+            observed_servers,
+        }
+    }
+
+    /// 観測された利用の一覧を取得
+    pub fn usages(&self) -> &[ObservedUsage] {
+        &self.usages
+    }
+
+    /// そのサーバーの利用状況を今このとき把握できているか
+    ///
+    /// `false`のサーバーについては、利用の一覧に現れないことが
+    /// 「使われていない」ことを意味しない。
+    pub fn covers(&self, server: &str) -> bool {
+        self.observed_servers.contains(server)
+    }
+
+    /// 利用の有無を把握できたサーバーの数
+    pub fn observed_server_count(&self) -> usize {
+        self.observed_servers.len()
+    }
+}
+
 /// 実サーバーの利用状況を観測するポート
 ///
 /// 監視手段（SSHポーリング、Prometheus/DCGM Exporter等）はInfrastructure層の実装に隠蔽される。
 #[async_trait]
 pub trait ResourceUsageObserver: Send + Sync {
     /// 現在アクティブな利用状況を取得
-    async fn observe_active_usages(&self) -> Result<Vec<ObservedUsage>, ObservationError>;
+    async fn observe_active_usages(&self) -> Result<ObservationSnapshot, ObservationError>;
 }
 
 /// 観測エラー

--- a/src/infrastructure/resource_usage_observer/mock.rs
+++ b/src/infrastructure/resource_usage_observer/mock.rs
@@ -1,5 +1,6 @@
+use crate::domain::aggregates::resource_usage::value_objects::Resource;
 use crate::domain::ports::resource_usage_observer::{
-    ObservationError, ObservedUsage, ResourceUsageObserver,
+    ObservationError, ObservationSnapshot, ObservedUsage, ResourceUsageObserver,
 };
 use async_trait::async_trait;
 use std::sync::{Arc, Mutex};
@@ -9,7 +10,7 @@ use std::sync::{Arc, Mutex};
 /// `set_active_usages`で観測結果を差し替えることで、実サーバーの状態変化を模擬できる。
 #[derive(Clone, Default)]
 pub struct MockResourceUsageObserver {
-    active_usages: Arc<Mutex<Vec<ObservedUsage>>>,
+    snapshot: Arc<Mutex<ObservationSnapshot>>,
 }
 
 impl MockResourceUsageObserver {
@@ -19,14 +20,32 @@ impl MockResourceUsageObserver {
     }
 
     /// 観測結果を差し替える
+    ///
+    /// 利用が観測されたサーバーは、観測できたサーバーとして扱う。
+    /// 「観測できたが誰も使っていないサーバー」や「観測できなかったサーバー」を
+    /// 模擬したい場合は`set_snapshot`を使う。
     pub fn set_active_usages(&self, usages: Vec<ObservedUsage>) {
-        *self.active_usages.lock().unwrap() = usages;
+        let servers = usages.iter().filter_map(server_of).collect();
+        *self.snapshot.lock().unwrap() = ObservationSnapshot::new(usages, servers);
+    }
+
+    /// 観測できたサーバーまで指定して観測結果を差し替える
+    pub fn set_snapshot(&self, snapshot: ObservationSnapshot) {
+        *self.snapshot.lock().unwrap() = snapshot;
+    }
+}
+
+/// 観測された利用が乗っているサーバー名（GPU以外のリソースはサーバーを持たない）
+fn server_of(usage: &ObservedUsage) -> Option<String> {
+    match usage.resource() {
+        Resource::Gpu(gpu) => Some(gpu.server().to_string()),
+        Resource::Room { .. } => None,
     }
 }
 
 #[async_trait]
 impl ResourceUsageObserver for MockResourceUsageObserver {
-    async fn observe_active_usages(&self) -> Result<Vec<ObservedUsage>, ObservationError> {
-        Ok(self.active_usages.lock().unwrap().clone())
+    async fn observe_active_usages(&self) -> Result<ObservationSnapshot, ObservationError> {
+        Ok(self.snapshot.lock().unwrap().clone())
     }
 }

--- a/src/infrastructure/resource_usage_observer/shared_file.rs
+++ b/src/infrastructure/resource_usage_observer/shared_file.rs
@@ -1,12 +1,13 @@
 use crate::domain::aggregates::identity_link::value_objects::{ExternalIdentity, ExternalSystem};
 use crate::domain::aggregates::resource_usage::value_objects::{Gpu, Resource};
 use crate::domain::ports::resource_usage_observer::{
-    ObservationError, ObservedUsage, ResourceUsageObserver,
+    ObservationError, ObservationSnapshot, ObservedUsage, ResourceUsageObserver,
 };
 use crate::infrastructure::config::ResourceConfig;
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tracing::warn;
@@ -76,15 +77,20 @@ impl SharedFileResourceUsageObserver {
             .join(format!("{}.json", server_name.to_lowercase()))
     }
 
-    async fn read_server_report(&self, server_name: &str) -> Vec<ObservedUsage> {
+    /// 1サーバー分のレポートを読む
+    ///
+    /// 利用状況を把握できなかった場合は`None`を返す。読めなかったことと
+    /// 「使われていない」ことを呼び出し側が取り違えないようにするため、
+    /// 空の一覧では表さない。
+    async fn read_server_report(&self, server_name: &str) -> Option<Vec<ObservedUsage>> {
         let path = self.report_path(server_name);
 
         let content = match tokio::fs::read_to_string(&path).await {
             Ok(content) => content,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Vec::new(),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
             Err(e) => {
                 warn!(path = %path.display(), error = %e, "reading a usage report failed");
-                return Vec::new();
+                return None;
             }
         };
 
@@ -92,7 +98,7 @@ impl SharedFileResourceUsageObserver {
             Ok(report) => report,
             Err(e) => {
                 warn!(path = %path.display(), error = %e, "parsing a usage report failed");
-                return Vec::new();
+                return None;
             }
         };
 
@@ -103,10 +109,10 @@ impl SharedFileResourceUsageObserver {
                 max_staleness_secs = self.max_staleness.num_seconds(),
                 "the usage report is too old; ignoring it"
             );
-            return Vec::new();
+            return None;
         }
 
-        self.build_observed_usages(&report)
+        Some(self.build_observed_usages(&report))
     }
 
     fn build_observed_usages(&self, report: &GpuUsageReport) -> Vec<ObservedUsage> {
@@ -149,12 +155,19 @@ impl SharedFileResourceUsageObserver {
 
 #[async_trait]
 impl ResourceUsageObserver for SharedFileResourceUsageObserver {
-    async fn observe_active_usages(&self) -> Result<Vec<ObservedUsage>, ObservationError> {
+    async fn observe_active_usages(&self) -> Result<ObservationSnapshot, ObservationError> {
         let mut observed = Vec::new();
+        let mut observed_servers = HashSet::new();
+
         for server in &self.resource_config.servers {
-            observed.extend(self.read_server_report(&server.name).await);
+            let Some(usages) = self.read_server_report(&server.name).await else {
+                continue;
+            };
+            observed.extend(usages);
+            observed_servers.insert(server.name.clone());
         }
-        Ok(observed)
+
+        Ok(ObservationSnapshot::new(observed, observed_servers))
     }
 }
 
@@ -188,13 +201,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_missing_file_returns_empty() {
+    async fn a_server_without_a_report_is_not_covered() {
         let dir = temp_dir();
         let observer =
             SharedFileResourceUsageObserver::new(dir, test_resource_config(), Duration::minutes(5));
 
-        let observed = observer.observe_active_usages().await.unwrap();
-        assert!(observed.is_empty());
+        let snapshot = observer.observe_active_usages().await.unwrap();
+
+        assert!(snapshot.usages().is_empty());
+        assert!(
+            !snapshot.covers("Thalys"),
+            "レポートがないサーバーの利用状況は分からない"
+        );
     }
 
     #[tokio::test]
@@ -220,9 +238,11 @@ mod tests {
             test_resource_config(),
             Duration::minutes(5),
         );
-        let observed = observer.observe_active_usages().await.unwrap();
+        let snapshot = observer.observe_active_usages().await.unwrap();
+        let observed = snapshot.usages();
 
         assert_eq!(observed.len(), 1);
+        assert!(snapshot.covers("Thalys"));
         assert_eq!(observed[0].external_identity().user_id(), "kkawaguchi");
         assert_eq!(observed[0].active_since(), started_at);
         match observed[0].resource() {
@@ -238,7 +258,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_stale_report_is_ignored() {
+    async fn a_stale_report_leaves_the_server_uncovered() {
         let dir = temp_dir();
         let generated_at = Utc::now() - Duration::minutes(30);
         let started_at = generated_at - Duration::minutes(20);
@@ -260,9 +280,13 @@ mod tests {
             test_resource_config(),
             Duration::minutes(5),
         );
-        let observed = observer.observe_active_usages().await.unwrap();
+        let snapshot = observer.observe_active_usages().await.unwrap();
 
-        assert!(observed.is_empty());
+        assert!(snapshot.usages().is_empty());
+        assert!(
+            !snapshot.covers("Thalys"),
+            "監視が止まっている間の沈黙を「使われていない」と読ませない"
+        );
 
         tokio::fs::remove_dir_all(&dir).await.ok();
     }
@@ -289,9 +313,13 @@ mod tests {
             test_resource_config(),
             Duration::minutes(5),
         );
-        let observed = observer.observe_active_usages().await.unwrap();
+        let snapshot = observer.observe_active_usages().await.unwrap();
 
-        assert!(observed.is_empty());
+        assert!(snapshot.usages().is_empty());
+        assert!(
+            snapshot.covers("Thalys"),
+            "レポートは読めているので、そのサーバーの利用状況は把握できている"
+        );
 
         tokio::fs::remove_dir_all(&dir).await.ok();
     }


### PR DESCRIPTION
The observer returned a flat list of usages, so a server whose report was
missing or stale looked exactly like a server where nobody was working.
Reading that silence as "unused" is about to matter: the next layer decides
whether a reservation is going unused, and a stopped reporter must not be
allowed to answer that question.

Observations now carry the set of servers whose usage is actually known.
Callers that only read the usage list behave as before.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EP2XesjWRdQ7EKhRmhEcb7

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>