### PR TITLE
feat: notice when a reservation is going unused

### DIFF
--- a/docs/ADMIN_GUIDE.md
+++ b/docs/ADMIN_GUIDE.md
@@ -240,6 +240,7 @@ the same shared directory used by `gpu-usage-reporter` above to enable it:
 | `GPU_USAGE_REPORTS_DIR` | (unset = feature disabled) | Shared directory read by `SharedFileResourceUsageObserver` |
 | `GPU_USAGE_MAX_STALENESS_SECS` | `300` | How old a report can be before it's ignored |
 | `UNRESERVED_USAGE_THRESHOLD_SECS` | `600` | How long unreserved usage must continue before a proposal is sent |
+| `IDLE_RESERVATION_THRESHOLD_SECS` | `1800` | How long a reservation must go unused by its owner before the owner is told. Reservations with less time left than this are left alone |
 | `RESERVATION_PROPOSAL_DURATION_CANDIDATES_HOURS` | `1,2,3,5,8` | Comma-separated hour candidates offered in the Slack DM |
 
 When enabled, a user whose OS account is linked (`/link-user`) and who also has a linked

--- a/docs/ADMIN_GUIDE_ja.md
+++ b/docs/ADMIN_GUIDE_ja.md
@@ -233,6 +233,7 @@ cronが停止した場合に古い利用状況を「今も使用中」と誤判�
 | `GPU_USAGE_REPORTS_DIR` | (未設定=機能無効) | `SharedFileResourceUsageObserver`が読み取る共有ディレクトリ |
 | `GPU_USAGE_MAX_STALENESS_SECS` | `300` | レポートを無視し始める経過時間（秒） |
 | `UNRESERVED_USAGE_THRESHOLD_SECS` | `600` | 未予約利用を提案対象とみなす継続時間の閾値（秒） |
+| `IDLE_RESERVATION_THRESHOLD_SECS` | `1800` | 予約者本人に使われていない予約を知らせるまでの時間（秒）。残り時間がこれに満たない予約には知らせない |
 | `RESERVATION_PROPOSAL_DURATION_CANDIDATES_HOURS` | `1,2,3,5,8` | Slack DMで提示する利用時間候補（時間、カンマ区切り） |
 
 有効化すると、OSアカウントが紐付け済み（`/link-user`）かつSlackアカウントも紐付け済みの利用者に、

--- a/src/application/idle_notice_log.rs
+++ b/src/application/idle_notice_log.rs
@@ -1,0 +1,80 @@
+//! 使われていない予約について、同じ予約で繰り返し声をかけないための記録
+
+use crate::domain::aggregates::resource_usage::value_objects::UsageId;
+use std::collections::HashSet;
+use std::sync::Mutex;
+
+/// 使われていない予約について、同じ予約で繰り返し声をかけないための記録
+///
+/// ビジネス上の不変条件ではなく、通知がうるさくならないようにするための状態である。
+/// プロセス内メモリのみで保持し永続化しない（再起動後に改めて知らせても実害はない）。
+/// 予約者が「まだ使う」と答えたときにも、その予約を黙らせるために使う。
+#[derive(Debug, Default)]
+pub struct IdleNoticeLog {
+    silenced: Mutex<HashSet<String>>,
+}
+
+impl IdleNoticeLog {
+    /// この予約について当面は声をかけないようにする
+    pub fn silence(&self, usage_id: &UsageId) {
+        self.silenced
+            .lock()
+            .unwrap()
+            .insert(usage_id.as_str().to_string());
+    }
+
+    /// この予約について声をかけずにいるか
+    pub fn is_silenced(&self, usage_id: &UsageId) -> bool {
+        self.silenced.lock().unwrap().contains(usage_id.as_str())
+    }
+
+    /// ふたたび声をかける対象に戻す
+    pub fn resume(&self, usage_id: &UsageId) {
+        self.silenced.lock().unwrap().remove(usage_id.as_str());
+    }
+
+    /// いま覚えておく意味のある予約についてだけ記録を残す
+    ///
+    /// 終わった予約について黙っていることに意味はない。放っておくと、
+    /// プロセスが動き続けるあいだ記録だけが増えていく。
+    pub fn retain_only(&self, is_worth_remembering: impl Fn(&str) -> bool) {
+        self.silenced
+            .lock()
+            .unwrap()
+            .retain(|usage_id| is_worth_remembering(usage_id));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_notice_log_keeps_only_what_is_worth_remembering() {
+        let kept = UsageId::from_string("running".to_string());
+        let dropped = UsageId::from_string("finished".to_string());
+        let log = IdleNoticeLog::default();
+        log.silence(&kept);
+        log.silence(&dropped);
+
+        log.retain_only(|usage_id| usage_id == kept.as_str());
+
+        assert!(log.is_silenced(&kept));
+        assert!(
+            !log.is_silenced(&dropped),
+            "終わった予約について黙り続ける意味はない"
+        );
+    }
+
+    #[test]
+    fn silencing_and_resuming_are_reversible() {
+        let usage_id = UsageId::from_string("running".to_string());
+        let log = IdleNoticeLog::default();
+
+        assert!(!log.is_silenced(&usage_id));
+        log.silence(&usage_id);
+        assert!(log.is_silenced(&usage_id));
+        log.resume(&usage_id);
+        assert!(!log.is_silenced(&usage_id));
+    }
+}

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -14,6 +14,9 @@
 
 /// Application層で発生するエラーの定義
 pub mod error;
+/// 使われていない予約を繰り返し知らせないための記録
+pub mod idle_notice_log;
 pub mod usecases;
 
 pub use error::ApplicationError;
+pub use idle_notice_log::IdleNoticeLog;

--- a/src/application/usecases/detect_idle_reservations.rs
+++ b/src/application/usecases/detect_idle_reservations.rs
@@ -1,0 +1,290 @@
+use crate::application::error::ApplicationError;
+use crate::domain::aggregates::identity_link::value_objects::{ExternalIdentity, ExternalSystem};
+use crate::domain::aggregates::resource_usage::entity::ResourceUsage;
+use crate::domain::aggregates::resource_usage::value_objects::{Resource, TimePeriod, UsageId};
+use crate::domain::ports::repositories::{IdentityLinkRepository, ResourceUsageRepository};
+use crate::domain::ports::{
+    IdleReservation, IdleReservationNotifier, ObservationSnapshot, ResourceUsageObserver,
+};
+use chrono::{DateTime, Duration, Utc};
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
+use tracing::{error, info};
+
+/// 使われていない予約について、同じ予約で繰り返し声をかけないための記録
+///
+/// ビジネス上の不変条件ではなく、通知がうるさくならないようにするための状態である。
+/// プロセス内メモリのみで保持し永続化しない（再起動後に改めて知らせても実害はない）。
+/// 予約者が「まだ使う」と答えたときにも、その予約を黙らせるために使う。
+#[derive(Debug, Default)]
+pub struct IdleNoticeLog {
+    silenced: Mutex<HashSet<String>>,
+}
+
+impl IdleNoticeLog {
+    /// この予約について当面は声をかけないようにする
+    pub fn silence(&self, usage_id: &UsageId) {
+        self.silenced
+            .lock()
+            .unwrap()
+            .insert(usage_id.as_str().to_string());
+    }
+
+    /// この予約について声をかけずにいるか
+    pub fn is_silenced(&self, usage_id: &UsageId) -> bool {
+        self.silenced.lock().unwrap().contains(usage_id.as_str())
+    }
+
+    /// ふたたび声をかける対象に戻す
+    pub fn resume(&self, usage_id: &UsageId) {
+        self.silenced.lock().unwrap().remove(usage_id.as_str());
+    }
+}
+
+/// 予約が使われているかどうかの見立て
+#[derive(Debug, PartialEq, Eq)]
+enum Verdict {
+    /// 予約者本人の利用が観測できている
+    InUse,
+    /// 予約者本人の利用が観測できない
+    Idle,
+    /// 使われているかを問えない（観測できないサーバー、OSユーザー未リンク、部屋の予約）
+    Undecidable,
+}
+
+/// 進行中の予約のうち、予約者本人に使われていないものを検知して知らせるユースケース
+///
+/// # 判定
+/// 予約が押さえているGPU上で、予約者本人のプロセスがひとつも観測されない状態が
+/// `idle_threshold`続いたら、予約者へ知らせる。予約者以外の利用は無断使用として
+/// `ReconcileObservedUsagesUseCase`が扱うため、ここでは予約者本人の利用だけを見る。
+///
+/// # 判定しない場合
+/// - 観測できていないサーバー（レポートの欠落・鮮度切れ）を含む予約
+///   監視が止まっている間の沈黙は、使われていないことの証拠にならない
+/// - 予約者のOSユーザー名が分からない予約
+///   本人の利用を本人のものと見分けられない
+/// - 部屋の予約
+///   利用を観測する手段がない
+/// - 残り時間が`idle_threshold`に満たない予約
+///   まもなく終わる予約を急かしても、予約者に取れる手はほとんどない
+pub struct DetectIdleReservationsUseCase<R, O, I, N>
+where
+    R: ResourceUsageRepository,
+    O: ResourceUsageObserver,
+    I: IdentityLinkRepository,
+    N: IdleReservationNotifier,
+{
+    repository: Arc<R>,
+    observer: Arc<O>,
+    identity_repo: Arc<I>,
+    notifier: N,
+    idle_threshold: Duration,
+    notices: Arc<IdleNoticeLog>,
+    /// 予約ごとの「使われていないと確かめられた最初の時刻」
+    idle_since: Mutex<HashMap<String, DateTime<Utc>>>,
+}
+
+impl<R, O, I, N> DetectIdleReservationsUseCase<R, O, I, N>
+where
+    R: ResourceUsageRepository,
+    O: ResourceUsageObserver,
+    I: IdentityLinkRepository,
+    N: IdleReservationNotifier,
+{
+    /// 新しいユースケースインスタンスを作成
+    ///
+    /// # Arguments
+    /// * `idle_threshold` - 使われていない状態が続いたときに知らせるまでの時間
+    /// * `notices` - 繰り返し声をかけないための記録（予約者の応答からも更新される）
+    pub fn new(
+        repository: Arc<R>,
+        observer: Arc<O>,
+        identity_repo: Arc<I>,
+        notifier: N,
+        idle_threshold: Duration,
+        notices: Arc<IdleNoticeLog>,
+    ) -> Self {
+        Self {
+            repository,
+            observer,
+            identity_repo,
+            notifier,
+            idle_threshold,
+            notices,
+            idle_since: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// 一度だけポーリングを実行し、使われていない予約を知らせる
+    ///
+    /// # Errors
+    /// 観測・リポジトリアクセスに失敗した場合（個別の通知失敗は記録して続行する）
+    pub async fn poll_once(&self) -> Result<(), ApplicationError> {
+        let started_at = Utc::now();
+        let now = started_at;
+        // 対象は「今この瞬間に進行中の予約」だけなので、現在時刻を含む最小の期間を問う
+        let in_progress = TimePeriod::new(now, now + Duration::seconds(1))?;
+        let reservations = self.repository.find_overlapping(&in_progress).await?;
+        let snapshot = self.observer.observe_active_usages().await?;
+
+        let mut idle = 0_usize;
+        let mut notified = 0_usize;
+        let mut failures = 0_usize;
+
+        for reservation in &reservations {
+            match self.judge(reservation, &snapshot).await? {
+                Verdict::InUse => self.forget(reservation.id()),
+                Verdict::Undecidable => {}
+                Verdict::Idle => {
+                    idle += 1;
+                    match self.notify_if_due(reservation, now).await {
+                        Ok(true) => notified += 1,
+                        Ok(false) => {}
+                        Err(e) => {
+                            failures += 1;
+                            error!(
+                                usage_id = %reservation.id().as_str(),
+                                error = %e,
+                                "telling the owner about an idle reservation failed"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        info!(
+            reservations_in_progress = reservations.len(),
+            servers_observed = snapshot.observed_server_count(),
+            idle,
+            notified,
+            failures,
+            elapsed_ms = (Utc::now() - started_at).num_milliseconds(),
+            "idle reservation pass finished"
+        );
+
+        Ok(())
+    }
+
+    /// 予約が予約者本人に使われているかを見立てる
+    async fn judge(
+        &self,
+        reservation: &ResourceUsage,
+        snapshot: &ObservationSnapshot,
+    ) -> Result<Verdict, ApplicationError> {
+        let Some(servers) = servers_of(reservation) else {
+            return Ok(Verdict::Undecidable);
+        };
+
+        if !servers.iter().all(|server| snapshot.covers(server)) {
+            return Ok(Verdict::Undecidable);
+        }
+
+        let Some(link) = self
+            .identity_repo
+            .find_by_email(reservation.owner_email())
+            .await?
+        else {
+            return Ok(Verdict::Undecidable);
+        };
+
+        let mut owner_identities: Vec<ExternalIdentity> = Vec::with_capacity(servers.len());
+        for server in &servers {
+            let system = ExternalSystem::Os {
+                server: server.clone(),
+            };
+            let Some(identity) = link.get_identity_for_system(&system) else {
+                return Ok(Verdict::Undecidable);
+            };
+            owner_identities.push(identity.clone());
+        }
+
+        let in_use = snapshot.usages().iter().any(|observed| {
+            owner_identities.contains(observed.external_identity())
+                && reservation
+                    .resources()
+                    .iter()
+                    .any(|reserved| reserved.conflicts_with(observed.resource()))
+        });
+
+        Ok(if in_use {
+            Verdict::InUse
+        } else {
+            Verdict::Idle
+        })
+    }
+
+    /// 使われていない時間が閾値に達していれば予約者へ知らせる
+    ///
+    /// 戻り値は実際に知らせたかどうか。
+    async fn notify_if_due(
+        &self,
+        reservation: &ResourceUsage,
+        now: DateTime<Utc>,
+    ) -> Result<bool, ApplicationError> {
+        let idle_since = self.idle_since_of(reservation.id(), now);
+
+        if now - idle_since < self.idle_threshold {
+            return Ok(false);
+        }
+
+        if reservation.time_period().end() - now < self.idle_threshold {
+            return Ok(false);
+        }
+
+        if self.notices.is_silenced(reservation.id()) {
+            return Ok(false);
+        }
+
+        info!(
+            usage_id = %reservation.id().as_str(),
+            owner = %reservation.owner_email().as_str(),
+            idle_since = %idle_since,
+            "telling the owner about an idle reservation"
+        );
+
+        self.notifier
+            .notify_idle(IdleReservation::new(reservation.clone(), idle_since))
+            .await?;
+        // 知らせられてから黙る。先に記録すると、送信に失敗したまま二度と知らせなくなる
+        self.notices.silence(reservation.id());
+        Ok(true)
+    }
+
+    /// この予約が使われていないと確かめられた最初の時刻（初めてなら今）
+    fn idle_since_of(&self, usage_id: &UsageId, now: DateTime<Utc>) -> DateTime<Utc> {
+        *self
+            .idle_since
+            .lock()
+            .unwrap()
+            .entry(usage_id.as_str().to_string())
+            .or_insert(now)
+    }
+
+    /// 使われ始めた予約を忘れる（次に使われなくなったら改めて知らせる）
+    fn forget(&self, usage_id: &UsageId) {
+        self.idle_since.lock().unwrap().remove(usage_id.as_str());
+        self.notices.resume(usage_id);
+    }
+}
+
+/// 予約が押さえているGPUのサーバー名（部屋を含む予約は観測の対象外）
+fn servers_of(reservation: &ResourceUsage) -> Option<HashSet<String>> {
+    let mut servers = HashSet::new();
+
+    for resource in reservation.resources() {
+        match resource {
+            Resource::Gpu(gpu) => {
+                servers.insert(gpu.server().to_string());
+            }
+            Resource::Room { .. } => return None,
+        }
+    }
+
+    if servers.is_empty() {
+        None
+    } else {
+        Some(servers)
+    }
+}

--- a/src/application/usecases/detect_idle_reservations.rs
+++ b/src/application/usecases/detect_idle_reservations.rs
@@ -1,4 +1,5 @@
 use crate::application::error::ApplicationError;
+use crate::application::idle_notice_log::IdleNoticeLog;
 use crate::domain::aggregates::identity_link::value_objects::{ExternalIdentity, ExternalSystem};
 use crate::domain::aggregates::resource_usage::entity::ResourceUsage;
 use crate::domain::aggregates::resource_usage::value_objects::{Resource, TimePeriod, UsageId};
@@ -10,47 +11,6 @@ use chrono::{DateTime, Duration, Utc};
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 use tracing::{error, info};
-
-/// 使われていない予約について、同じ予約で繰り返し声をかけないための記録
-///
-/// ビジネス上の不変条件ではなく、通知がうるさくならないようにするための状態である。
-/// プロセス内メモリのみで保持し永続化しない（再起動後に改めて知らせても実害はない）。
-/// 予約者が「まだ使う」と答えたときにも、その予約を黙らせるために使う。
-#[derive(Debug, Default)]
-pub struct IdleNoticeLog {
-    silenced: Mutex<HashSet<String>>,
-}
-
-impl IdleNoticeLog {
-    /// この予約について当面は声をかけないようにする
-    pub fn silence(&self, usage_id: &UsageId) {
-        self.silenced
-            .lock()
-            .unwrap()
-            .insert(usage_id.as_str().to_string());
-    }
-
-    /// この予約について声をかけずにいるか
-    pub fn is_silenced(&self, usage_id: &UsageId) -> bool {
-        self.silenced.lock().unwrap().contains(usage_id.as_str())
-    }
-
-    /// ふたたび声をかける対象に戻す
-    pub fn resume(&self, usage_id: &UsageId) {
-        self.silenced.lock().unwrap().remove(usage_id.as_str());
-    }
-
-    /// いま覚えておく意味のある予約についてだけ記録を残す
-    ///
-    /// 終わった予約について黙っていることに意味はない。放っておくと、
-    /// プロセスが動き続けるあいだ記録だけが増えていく。
-    pub fn retain_only(&self, is_worth_remembering: impl Fn(&str) -> bool) {
-        self.silenced
-            .lock()
-            .unwrap()
-            .retain(|usage_id| is_worth_remembering(usage_id));
-    }
-}
 
 /// 予約が使われているかどうかの見立て
 enum Verdict {
@@ -384,23 +344,6 @@ mod tests {
                 Duration::minutes(30)
             ),
             "開けられる時間がほとんどない予約を急かさない"
-        );
-    }
-
-    #[test]
-    fn a_notice_log_keeps_only_what_is_worth_remembering() {
-        let kept = UsageId::from_string("running".to_string());
-        let dropped = UsageId::from_string("finished".to_string());
-        let log = IdleNoticeLog::default();
-        log.silence(&kept);
-        log.silence(&dropped);
-
-        log.retain_only(|usage_id| usage_id == kept.as_str());
-
-        assert!(log.is_silenced(&kept));
-        assert!(
-            !log.is_silenced(&dropped),
-            "終わった予約について黙り続ける意味はない"
         );
     }
 

--- a/src/application/usecases/detect_idle_reservations.rs
+++ b/src/application/usecases/detect_idle_reservations.rs
@@ -39,10 +39,20 @@ impl IdleNoticeLog {
     pub fn resume(&self, usage_id: &UsageId) {
         self.silenced.lock().unwrap().remove(usage_id.as_str());
     }
+
+    /// いま覚えておく意味のある予約についてだけ記録を残す
+    ///
+    /// 終わった予約について黙っていることに意味はない。放っておくと、
+    /// プロセスが動き続けるあいだ記録だけが増えていく。
+    pub fn retain_only(&self, is_worth_remembering: impl Fn(&str) -> bool) {
+        self.silenced
+            .lock()
+            .unwrap()
+            .retain(|usage_id| is_worth_remembering(usage_id));
+    }
 }
 
 /// 予約が使われているかどうかの見立て
-#[derive(Debug, PartialEq, Eq)]
 enum Verdict {
     /// 予約者本人の利用が観測できている
     InUse,
@@ -154,6 +164,8 @@ where
             }
         }
 
+        self.forget_reservations_that_ended(&reservations);
+
         info!(
             reservations_in_progress = reservations.len(),
             servers_observed = snapshot.observed_server_count(),
@@ -225,11 +237,7 @@ where
     ) -> Result<bool, ApplicationError> {
         let idle_since = self.idle_since_of(reservation.id(), now);
 
-        if now - idle_since < self.idle_threshold {
-            return Ok(false);
-        }
-
-        if reservation.time_period().end() - now < self.idle_threshold {
+        if !is_worth_telling(reservation, idle_since, now, self.idle_threshold) {
             return Ok(false);
         }
 
@@ -267,6 +275,24 @@ where
         self.idle_since.lock().unwrap().remove(usage_id.as_str());
         self.notices.resume(usage_id);
     }
+
+    /// 進行中でなくなった予約についての記録を落とす
+    ///
+    /// 終わった予約に対して知らせることはもう何もない。記録を持ち続けても
+    /// 増えていくだけで、次に同じ予約が現れることもない。
+    fn forget_reservations_that_ended(&self, in_progress: &[ResourceUsage]) {
+        let still_running: HashSet<&str> = in_progress
+            .iter()
+            .map(|reservation| reservation.id().as_str())
+            .collect();
+
+        self.idle_since
+            .lock()
+            .unwrap()
+            .retain(|usage_id, _| still_running.contains(usage_id.as_str()));
+        self.notices
+            .retain_only(|usage_id| still_running.contains(usage_id));
+    }
 }
 
 /// 予約が押さえているGPUのサーバー名（部屋を含む予約は観測の対象外）
@@ -282,9 +308,112 @@ fn servers_of(reservation: &ResourceUsage) -> Option<HashSet<String>> {
         }
     }
 
-    if servers.is_empty() {
-        None
-    } else {
-        Some(servers)
+    Some(servers)
+}
+
+/// 使われていない予約について、いま予約者へ知らせるべきか
+///
+/// 使われていない時間が閾値に達していても、残り時間が閾値に満たなければ知らせない。
+/// まもなく終わる予約を急かしても、予約者が開けられる時間はほとんど残っていない。
+fn is_worth_telling(
+    reservation: &ResourceUsage,
+    idle_since: DateTime<Utc>,
+    now: DateTime<Utc>,
+    threshold: Duration,
+) -> bool {
+    now - idle_since >= threshold && reservation.time_period().end() - now >= threshold
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::aggregates::resource_usage::value_objects::{Gpu, TimePeriod};
+    use crate::domain::common::EmailAddress;
+
+    fn reservation_ending_in(remaining: Duration, now: DateTime<Utc>) -> ResourceUsage {
+        ResourceUsage::new(
+            EmailAddress::new("owner@example.com".to_string()).unwrap(),
+            TimePeriod::new(now - Duration::hours(1), now + remaining).unwrap(),
+            vec![Resource::Gpu(Gpu::new(
+                "Thalys".to_string(),
+                0,
+                "A100".to_string(),
+            ))],
+            None,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn an_idle_stretch_shorter_than_the_threshold_is_not_worth_telling() {
+        let now = Utc::now();
+        let reservation = reservation_ending_in(Duration::hours(4), now);
+
+        assert!(!is_worth_telling(
+            &reservation,
+            now - Duration::minutes(20),
+            now,
+            Duration::minutes(30)
+        ));
+    }
+
+    #[test]
+    fn an_idle_stretch_past_the_threshold_is_worth_telling() {
+        let now = Utc::now();
+        let reservation = reservation_ending_in(Duration::hours(4), now);
+
+        assert!(is_worth_telling(
+            &reservation,
+            now - Duration::minutes(31),
+            now,
+            Duration::minutes(30)
+        ));
+    }
+
+    #[test]
+    fn a_reservation_about_to_end_is_not_worth_telling() {
+        let now = Utc::now();
+        // 1時間使われていないが、残りは10分しかない
+        let reservation = reservation_ending_in(Duration::minutes(10), now);
+
+        assert!(
+            !is_worth_telling(
+                &reservation,
+                now - Duration::hours(1),
+                now,
+                Duration::minutes(30)
+            ),
+            "開けられる時間がほとんどない予約を急かさない"
+        );
+    }
+
+    #[test]
+    fn a_notice_log_keeps_only_what_is_worth_remembering() {
+        let kept = UsageId::from_string("running".to_string());
+        let dropped = UsageId::from_string("finished".to_string());
+        let log = IdleNoticeLog::default();
+        log.silence(&kept);
+        log.silence(&dropped);
+
+        log.retain_only(|usage_id| usage_id == kept.as_str());
+
+        assert!(log.is_silenced(&kept));
+        assert!(
+            !log.is_silenced(&dropped),
+            "終わった予約について黙り続ける意味はない"
+        );
+    }
+
+    #[test]
+    fn a_reservation_with_exactly_the_threshold_left_is_still_worth_telling() {
+        let now = Utc::now();
+        let reservation = reservation_ending_in(Duration::minutes(30), now);
+
+        assert!(is_worth_telling(
+            &reservation,
+            now - Duration::minutes(30),
+            now,
+            Duration::minutes(30)
+        ));
     }
 }

--- a/src/application/usecases/detect_idle_reservations_tests.rs
+++ b/src/application/usecases/detect_idle_reservations_tests.rs
@@ -2,9 +2,8 @@
 //!
 //! 予約者本人に使われていない予約の見分け方と、知らせる/知らせない条件を検証する。
 
-use crate::application::usecases::detect_idle_reservations::{
-    DetectIdleReservationsUseCase, IdleNoticeLog,
-};
+use crate::application::idle_notice_log::IdleNoticeLog;
+use crate::application::usecases::detect_idle_reservations::DetectIdleReservationsUseCase;
 use crate::application::usecases::test_support::InMemoryIdentityLinkRepository;
 use crate::domain::aggregates::identity_link::value_objects::{ExternalIdentity, ExternalSystem};
 use crate::domain::aggregates::resource_usage::entity::ResourceUsage;

--- a/src/application/usecases/detect_idle_reservations_tests.rs
+++ b/src/application/usecases/detect_idle_reservations_tests.rs
@@ -1,0 +1,343 @@
+//! `DetectIdleReservationsUseCase`のテスト
+//!
+//! 予約者本人に使われていない予約の見分け方と、知らせる/知らせない条件を検証する。
+
+use crate::application::usecases::detect_idle_reservations::{
+    DetectIdleReservationsUseCase, IdleNoticeLog,
+};
+use crate::application::usecases::test_support::InMemoryIdentityLinkRepository;
+use crate::domain::aggregates::identity_link::value_objects::{ExternalIdentity, ExternalSystem};
+use crate::domain::aggregates::resource_usage::entity::ResourceUsage;
+use crate::domain::aggregates::resource_usage::value_objects::{Gpu, Resource, TimePeriod};
+use crate::domain::common::EmailAddress;
+use crate::domain::ports::repositories::ResourceUsageRepository;
+use crate::domain::ports::{ObservationSnapshot, ObservedUsage};
+use crate::infrastructure::idle_reservation_notifier::MockIdleReservationNotifier;
+use crate::infrastructure::repositories::resource_usage::mock::MockUsageRepository;
+use crate::infrastructure::resource_usage_observer::MockResourceUsageObserver;
+use chrono::{DateTime, Duration, Utc};
+use std::collections::HashSet;
+use std::sync::Arc;
+
+const SERVER: &str = "Thalys";
+
+type TestUseCase = DetectIdleReservationsUseCase<
+    MockUsageRepository,
+    MockResourceUsageObserver,
+    InMemoryIdentityLinkRepository,
+    MockIdleReservationNotifier,
+>;
+
+struct Fixture {
+    usecase: TestUseCase,
+    repository: Arc<MockUsageRepository>,
+    observer: Arc<MockResourceUsageObserver>,
+    identity_repo: Arc<InMemoryIdentityLinkRepository>,
+    notifier: MockIdleReservationNotifier,
+    notices: Arc<IdleNoticeLog>,
+}
+
+fn fixture(threshold_minutes: i64) -> Fixture {
+    let repository = Arc::new(MockUsageRepository::new());
+    let observer = Arc::new(MockResourceUsageObserver::new());
+    let identity_repo = Arc::new(InMemoryIdentityLinkRepository::default());
+    let notifier = MockIdleReservationNotifier::new();
+    let notices = Arc::new(IdleNoticeLog::default());
+
+    let usecase = DetectIdleReservationsUseCase::new(
+        repository.clone(),
+        observer.clone(),
+        identity_repo.clone(),
+        notifier.clone(),
+        Duration::minutes(threshold_minutes),
+        notices.clone(),
+    );
+
+    Fixture {
+        usecase,
+        repository,
+        observer,
+        identity_repo,
+        notifier,
+        notices,
+    }
+}
+
+fn os_system() -> ExternalSystem {
+    ExternalSystem::Os {
+        server: SERVER.to_string(),
+    }
+}
+
+fn gpu(device_number: u32) -> Resource {
+    Resource::Gpu(Gpu::new(
+        SERVER.to_string(),
+        device_number,
+        "A100".to_string(),
+    ))
+}
+
+fn reservation_of(owner: &str, resources: Vec<Resource>, ends_in: Duration) -> ResourceUsage {
+    let now = Utc::now();
+    ResourceUsage::new(
+        EmailAddress::new(owner.to_string()).unwrap(),
+        TimePeriod::new(now - Duration::hours(1), now + ends_in).unwrap(),
+        resources,
+        None,
+    )
+    .unwrap()
+}
+
+fn observed_by(user_id: &str, resource: Resource, active_since: DateTime<Utc>) -> ObservedUsage {
+    ObservedUsage::new(
+        resource,
+        ExternalIdentity::new(os_system(), user_id.to_string()),
+        active_since,
+    )
+}
+
+/// 誰の利用も観測されなかったが、サーバーの状態は把握できている観測結果
+fn nobody_is_working() -> ObservationSnapshot {
+    ObservationSnapshot::new(Vec::new(), HashSet::from([SERVER.to_string()]))
+}
+
+#[tokio::test]
+async fn a_reservation_its_owner_is_using_is_left_alone() {
+    let f = fixture(30);
+    f.identity_repo
+        .add_link("owner@example.com", os_system(), "owner-os");
+    let reservation = reservation_of("owner@example.com", vec![gpu(0)], Duration::hours(4));
+    f.repository.save(&reservation).await.unwrap();
+
+    f.observer.set_active_usages(vec![observed_by(
+        "owner-os",
+        gpu(0),
+        Utc::now() - Duration::hours(1),
+    )]);
+
+    f.usecase.poll_once().await.unwrap();
+
+    assert!(f.notifier.sent_notices().is_empty());
+}
+
+#[tokio::test]
+async fn an_unused_reservation_is_reported_once_the_threshold_passes() {
+    let f = fixture(0);
+    f.identity_repo
+        .add_link("owner@example.com", os_system(), "owner-os");
+    let reservation = reservation_of("owner@example.com", vec![gpu(0)], Duration::hours(4));
+    f.repository.save(&reservation).await.unwrap();
+    f.observer.set_snapshot(nobody_is_working());
+
+    f.usecase.poll_once().await.unwrap();
+
+    let notices = f.notifier.sent_notices();
+    assert_eq!(notices.len(), 1);
+    assert_eq!(notices[0].reservation().id(), reservation.id());
+}
+
+#[tokio::test]
+async fn the_owner_is_not_told_twice_about_the_same_reservation() {
+    let f = fixture(0);
+    f.identity_repo
+        .add_link("owner@example.com", os_system(), "owner-os");
+    let reservation = reservation_of("owner@example.com", vec![gpu(0)], Duration::hours(4));
+    f.repository.save(&reservation).await.unwrap();
+    f.observer.set_snapshot(nobody_is_working());
+
+    f.usecase.poll_once().await.unwrap();
+    f.usecase.poll_once().await.unwrap();
+    f.usecase.poll_once().await.unwrap();
+
+    assert_eq!(f.notifier.sent_notices().len(), 1);
+}
+
+#[tokio::test]
+async fn nothing_is_said_before_the_reservation_has_been_idle_long_enough() {
+    let f = fixture(30);
+    f.identity_repo
+        .add_link("owner@example.com", os_system(), "owner-os");
+    let reservation = reservation_of("owner@example.com", vec![gpu(0)], Duration::hours(4));
+    f.repository.save(&reservation).await.unwrap();
+    f.observer.set_snapshot(nobody_is_working());
+
+    f.usecase.poll_once().await.unwrap();
+
+    assert!(
+        f.notifier.sent_notices().is_empty(),
+        "使われていないと分かった直後に急かさない"
+    );
+}
+
+#[tokio::test]
+async fn a_server_that_cannot_be_observed_says_nothing_about_its_reservations() {
+    let f = fixture(0);
+    f.identity_repo
+        .add_link("owner@example.com", os_system(), "owner-os");
+    let reservation = reservation_of("owner@example.com", vec![gpu(0)], Duration::hours(4));
+    f.repository.save(&reservation).await.unwrap();
+
+    // レポートが届かない（cron停止・鮮度切れ）サーバー
+    f.observer
+        .set_snapshot(ObservationSnapshot::new(Vec::new(), HashSet::new()));
+
+    f.usecase.poll_once().await.unwrap();
+
+    assert!(
+        f.notifier.sent_notices().is_empty(),
+        "監視が止まっている間の沈黙を、使っていないことの証拠にしてはいけない"
+    );
+}
+
+#[tokio::test]
+async fn an_owner_without_a_linked_os_username_is_left_alone() {
+    let f = fixture(0);
+    // Slackは紐付いているが、このサーバーのOSユーザー名は分からない
+    f.identity_repo
+        .add_link("owner@example.com", ExternalSystem::Slack, "U123");
+    let reservation = reservation_of("owner@example.com", vec![gpu(0)], Duration::hours(4));
+    f.repository.save(&reservation).await.unwrap();
+    f.observer.set_snapshot(nobody_is_working());
+
+    f.usecase.poll_once().await.unwrap();
+
+    assert!(
+        f.notifier.sent_notices().is_empty(),
+        "本人の利用を本人のものと見分けられないなら判定できない"
+    );
+}
+
+#[tokio::test]
+async fn someone_else_working_on_the_gpu_does_not_count_as_the_owner_using_it() {
+    let f = fixture(0);
+    f.identity_repo
+        .add_link("owner@example.com", os_system(), "owner-os");
+    f.identity_repo
+        .add_link("guest@example.com", os_system(), "guest-os");
+    let reservation = reservation_of("owner@example.com", vec![gpu(0)], Duration::hours(4));
+    f.repository.save(&reservation).await.unwrap();
+
+    f.observer.set_active_usages(vec![observed_by(
+        "guest-os",
+        gpu(0),
+        Utc::now() - Duration::hours(1),
+    )]);
+
+    f.usecase.poll_once().await.unwrap();
+
+    assert_eq!(
+        f.notifier.sent_notices().len(),
+        1,
+        "予約者本人が使っていない以上、予約は使われていない"
+    );
+}
+
+#[tokio::test]
+async fn a_reservation_about_to_end_is_left_alone() {
+    let f = fixture(30);
+    f.identity_repo
+        .add_link("owner@example.com", os_system(), "owner-os");
+    // 残り10分。ここで解放を促しても、開けられる時間はほとんどない
+    let reservation = reservation_of("owner@example.com", vec![gpu(0)], Duration::minutes(10));
+    f.repository.save(&reservation).await.unwrap();
+    f.observer.set_snapshot(nobody_is_working());
+
+    f.usecase.poll_once().await.unwrap();
+    f.usecase.poll_once().await.unwrap();
+
+    assert!(f.notifier.sent_notices().is_empty());
+}
+
+#[tokio::test]
+async fn a_room_reservation_is_out_of_scope() {
+    let f = fixture(0);
+    f.identity_repo
+        .add_link("owner@example.com", os_system(), "owner-os");
+    let reservation = reservation_of(
+        "owner@example.com",
+        vec![Resource::Room {
+            name: "会議室A".to_string(),
+        }],
+        Duration::hours(4),
+    );
+    f.repository.save(&reservation).await.unwrap();
+    f.observer.set_snapshot(nobody_is_working());
+
+    f.usecase.poll_once().await.unwrap();
+
+    assert!(
+        f.notifier.sent_notices().is_empty(),
+        "部屋の利用は観測できないので、使われているかを問えない"
+    );
+}
+
+#[tokio::test]
+async fn a_reservation_that_is_used_again_can_be_reported_again() {
+    let f = fixture(0);
+    f.identity_repo
+        .add_link("owner@example.com", os_system(), "owner-os");
+    let reservation = reservation_of("owner@example.com", vec![gpu(0)], Duration::hours(4));
+    f.repository.save(&reservation).await.unwrap();
+
+    f.observer.set_snapshot(nobody_is_working());
+    f.usecase.poll_once().await.unwrap();
+    assert_eq!(f.notifier.sent_notices().len(), 1);
+
+    // 予約者が使い始めた
+    f.observer.set_active_usages(vec![observed_by(
+        "owner-os",
+        gpu(0),
+        Utc::now() - Duration::minutes(5),
+    )]);
+    f.usecase.poll_once().await.unwrap();
+
+    // そしてまた手が止まった
+    f.observer.set_snapshot(nobody_is_working());
+    f.usecase.poll_once().await.unwrap();
+
+    assert_eq!(
+        f.notifier.sent_notices().len(),
+        2,
+        "一度使われたなら、次に手が止まったときは改めて知らせる"
+    );
+}
+
+#[tokio::test]
+async fn a_failed_notice_is_retried_on_the_next_pass() {
+    let f = fixture(0);
+    f.identity_repo
+        .add_link("owner@example.com", os_system(), "owner-os");
+    let reservation = reservation_of("owner@example.com", vec![gpu(0)], Duration::hours(4));
+    f.repository.save(&reservation).await.unwrap();
+    f.observer.set_snapshot(nobody_is_working());
+
+    f.notifier.set_failing(true);
+    f.usecase.poll_once().await.unwrap();
+    assert!(f.notifier.sent_notices().is_empty());
+
+    f.notifier.set_failing(false);
+    f.usecase.poll_once().await.unwrap();
+
+    assert_eq!(
+        f.notifier.sent_notices().len(),
+        1,
+        "送信に失敗しただけで二度と知らせなくなってはいけない"
+    );
+}
+
+#[tokio::test]
+async fn a_silenced_reservation_stays_quiet() {
+    let f = fixture(0);
+    f.identity_repo
+        .add_link("owner@example.com", os_system(), "owner-os");
+    let reservation = reservation_of("owner@example.com", vec![gpu(0)], Duration::hours(4));
+    f.repository.save(&reservation).await.unwrap();
+    f.observer.set_snapshot(nobody_is_working());
+
+    // 予約者が「まだ使う」と答えた状況
+    f.notices.silence(reservation.id());
+
+    f.usecase.poll_once().await.unwrap();
+
+    assert!(f.notifier.sent_notices().is_empty());
+}

--- a/src/application/usecases/detect_idle_reservations_tests.rs
+++ b/src/application/usecases/detect_idle_reservations_tests.rs
@@ -233,22 +233,6 @@ async fn someone_else_working_on_the_gpu_does_not_count_as_the_owner_using_it() 
 }
 
 #[tokio::test]
-async fn a_reservation_about_to_end_is_left_alone() {
-    let f = fixture(30);
-    f.identity_repo
-        .add_link("owner@example.com", os_system(), "owner-os");
-    // 残り10分。ここで解放を促しても、開けられる時間はほとんどない
-    let reservation = reservation_of("owner@example.com", vec![gpu(0)], Duration::minutes(10));
-    f.repository.save(&reservation).await.unwrap();
-    f.observer.set_snapshot(nobody_is_working());
-
-    f.usecase.poll_once().await.unwrap();
-    f.usecase.poll_once().await.unwrap();
-
-    assert!(f.notifier.sent_notices().is_empty());
-}
-
-#[tokio::test]
 async fn a_room_reservation_is_out_of_scope() {
     let f = fixture(0);
     f.identity_repo

--- a/src/application/usecases/mod.rs
+++ b/src/application/usecases/mod.rs
@@ -76,7 +76,7 @@ pub mod update_resource_usage;
 pub use accept_reservation_proposal::AcceptReservationProposalUseCase;
 pub use create_resource_usage::CreateResourceUsageUseCase;
 pub use delete_resource_usage::DeleteResourceUsageUseCase;
-pub use detect_idle_reservations::{DetectIdleReservationsUseCase, IdleNoticeLog};
+pub use detect_idle_reservations::DetectIdleReservationsUseCase;
 pub use get_resource_usage_by_id::GetResourceUsageByIdUseCase;
 pub use grant_user_resource_access::GrantUserResourceAccessUseCase;
 pub use list_all_future_resource_usages::ListAllFutureResourceUsagesUseCase;

--- a/src/application/usecases/mod.rs
+++ b/src/application/usecases/mod.rs
@@ -48,6 +48,10 @@ pub mod accept_reservation_proposal;
 pub mod create_resource_usage;
 /// リソース使用予定を削除するユースケース
 pub mod delete_resource_usage;
+/// 使われていない予約を検知して知らせるユースケース
+pub mod detect_idle_reservations;
+#[cfg(test)]
+mod detect_idle_reservations_tests;
 /// IDでリソース使用予定を取得するユースケース
 pub mod get_resource_usage_by_id;
 /// ユーザーにリソースアクセス権を付与するユースケース
@@ -64,12 +68,15 @@ pub mod reconcile_observed_usages;
 mod reconcile_observed_usages_tests;
 /// 進行中のリソース使用予定を今の時点で締めるユースケース
 pub mod release_resource_usage_early;
+#[cfg(test)]
+pub mod test_support;
 /// リソース使用予定を更新するユースケース
 pub mod update_resource_usage;
 
 pub use accept_reservation_proposal::AcceptReservationProposalUseCase;
 pub use create_resource_usage::CreateResourceUsageUseCase;
 pub use delete_resource_usage::DeleteResourceUsageUseCase;
+pub use detect_idle_reservations::{DetectIdleReservationsUseCase, IdleNoticeLog};
 pub use get_resource_usage_by_id::GetResourceUsageByIdUseCase;
 pub use grant_user_resource_access::GrantUserResourceAccessUseCase;
 pub use list_all_future_resource_usages::ListAllFutureResourceUsagesUseCase;

--- a/src/application/usecases/reconcile_observed_usages_tests.rs
+++ b/src/application/usecases/reconcile_observed_usages_tests.rs
@@ -3,16 +3,12 @@
 //! 実利用と予約の突合、無断使用の通知、事後予約提案のまとめ方を検証する。
 
 use crate::application::usecases::reconcile_observed_usages::ReconcileObservedUsagesUseCase;
-use crate::domain::aggregates::identity_link::{
-    entity::IdentityLink,
-    value_objects::{ExternalIdentity, ExternalSystem},
-};
+use crate::application::usecases::test_support::InMemoryIdentityLinkRepository;
+use crate::domain::aggregates::identity_link::value_objects::{ExternalIdentity, ExternalSystem};
 use crate::domain::aggregates::resource_usage::entity::ResourceUsage;
 use crate::domain::aggregates::resource_usage::value_objects::{Gpu, Resource, TimePeriod};
 use crate::domain::common::EmailAddress;
-use crate::domain::ports::repositories::{
-    IdentityLinkRepository, RepositoryError, ResourceUsageRepository,
-};
+use crate::domain::ports::repositories::ResourceUsageRepository;
 use crate::domain::ports::{
     NotificationError, ObservedUsage, ReservationProposal, ReservationProposalNotifier,
     UnauthorizedUsageNotifier,
@@ -22,57 +18,9 @@ use crate::infrastructure::reservation_proposal::MockReservationProposalNotifier
 use crate::infrastructure::resource_usage_observer::MockResourceUsageObserver;
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
-
-#[derive(Default)]
-struct InMemoryIdentityLinkRepository {
-    links: StdMutex<HashMap<String, IdentityLink>>,
-}
-
-impl InMemoryIdentityLinkRepository {
-    fn add_link(&self, email: &str, system: ExternalSystem, user_id: &str) {
-        let email_addr = EmailAddress::new(email.to_string()).unwrap();
-        let identity = ExternalIdentity::new(system, user_id.to_string());
-        let link = IdentityLink::with_external_identity(email_addr.clone(), identity);
-        self.links
-            .lock()
-            .unwrap()
-            .insert(email_addr.as_str().to_string(), link);
-    }
-}
-
-#[async_trait]
-impl IdentityLinkRepository for InMemoryIdentityLinkRepository {
-    async fn find_by_email(
-        &self,
-        email: &EmailAddress,
-    ) -> Result<Option<IdentityLink>, RepositoryError> {
-        Ok(self.links.lock().unwrap().get(email.as_str()).cloned())
-    }
-
-    async fn find_by_external_user_id(
-        &self,
-        system: &ExternalSystem,
-        user_id: &str,
-    ) -> Result<Option<IdentityLink>, RepositoryError> {
-        let links = self.links.lock().unwrap();
-        let found = links.values().find(|link| {
-            link.get_identity_for_system(system)
-                .is_some_and(|identity| identity.user_id() == user_id)
-        });
-        Ok(found.cloned())
-    }
-
-    async fn save(&self, identity_link: IdentityLink) -> Result<(), RepositoryError> {
-        self.links
-            .lock()
-            .unwrap()
-            .insert(identity_link.email().as_str().to_string(), identity_link);
-        Ok(())
-    }
-}
 
 #[derive(Clone, Default)]
 struct RecordingUnauthorizedUsageNotifier {

--- a/src/application/usecases/test_support.rs
+++ b/src/application/usecases/test_support.rs
@@ -1,0 +1,64 @@
+//! ユースケースのテストで共有する部品
+
+use crate::domain::aggregates::identity_link::{
+    entity::IdentityLink,
+    value_objects::{ExternalIdentity, ExternalSystem},
+};
+use crate::domain::common::EmailAddress;
+use crate::domain::ports::repositories::{IdentityLinkRepository, RepositoryError};
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+/// メモリ上でID紐付けを保持するテスト用リポジトリ
+#[derive(Default)]
+pub struct InMemoryIdentityLinkRepository {
+    links: Mutex<HashMap<String, IdentityLink>>,
+}
+
+impl InMemoryIdentityLinkRepository {
+    /// メールアドレスと外部システムの識別子を紐付ける
+    ///
+    /// 同じメールアドレスに複数の外部システムを紐付けられる（Slackと各サーバーのOSユーザーなど）。
+    pub fn add_link(&self, email: &str, system: ExternalSystem, user_id: &str) {
+        let email_addr = EmailAddress::new(email.to_string()).unwrap();
+        let identity = ExternalIdentity::new(system, user_id.to_string());
+
+        let mut links = self.links.lock().unwrap();
+        let link = links
+            .entry(email_addr.as_str().to_string())
+            .or_insert_with(|| IdentityLink::new(email_addr.clone()));
+        link.link_external_identity(identity).ok();
+    }
+}
+
+#[async_trait]
+impl IdentityLinkRepository for InMemoryIdentityLinkRepository {
+    async fn find_by_email(
+        &self,
+        email: &EmailAddress,
+    ) -> Result<Option<IdentityLink>, RepositoryError> {
+        Ok(self.links.lock().unwrap().get(email.as_str()).cloned())
+    }
+
+    async fn find_by_external_user_id(
+        &self,
+        system: &ExternalSystem,
+        user_id: &str,
+    ) -> Result<Option<IdentityLink>, RepositoryError> {
+        let links = self.links.lock().unwrap();
+        let found = links.values().find(|link| {
+            link.get_identity_for_system(system)
+                .is_some_and(|identity| identity.user_id() == user_id)
+        });
+        Ok(found.cloned())
+    }
+
+    async fn save(&self, identity_link: IdentityLink) -> Result<(), RepositoryError> {
+        self.links
+            .lock()
+            .unwrap()
+            .insert(identity_link.email().as_str().to_string(), identity_link);
+        Ok(())
+    }
+}

--- a/src/domain/ports/idle_reservation_notifier.rs
+++ b/src/domain/ports/idle_reservation_notifier.rs
@@ -1,0 +1,58 @@
+use crate::domain::aggregates::resource_usage::entity::ResourceUsage;
+use crate::domain::ports::notifier::NotificationError;
+use async_trait::async_trait;
+use chrono::{DateTime, Duration, Utc};
+
+/// 押さえられているのに使われていない予約
+///
+/// 予約は場所取りではなく使う約束である。使わないまま抱えられていると、
+/// 他の利用者は実際には空いている時間を待つことになる。
+#[derive(Debug, Clone)]
+pub struct IdleReservation {
+    reservation: ResourceUsage,
+    idle_since: DateTime<Utc>,
+}
+
+impl IdleReservation {
+    /// 新しい検知結果を作成
+    ///
+    /// # Arguments
+    /// * `reservation` - 対象の予約
+    /// * `idle_since` - 使われていないと分かっている最も早い時刻
+    pub fn new(reservation: ResourceUsage, idle_since: DateTime<Utc>) -> Self {
+        Self {
+            reservation,
+            idle_since,
+        }
+    }
+
+    /// 対象の予約を取得
+    pub fn reservation(&self) -> &ResourceUsage {
+        &self.reservation
+    }
+
+    /// 使われていないと分かっている最も早い時刻を取得
+    ///
+    /// 監視が始まる前のことは分からないため、これは「使われなくなった時刻」ではなく
+    /// 「使われていないと確かめられた最初の時刻」である。
+    pub fn idle_since(&self) -> DateTime<Utc> {
+        self.idle_since
+    }
+
+    /// 使われないまま経った時間
+    pub fn idle_for(&self, now: DateTime<Utc>) -> Duration {
+        now - self.idle_since
+    }
+}
+
+/// 使われていない予約を予約者本人へ知らせるポート
+///
+/// 予約チャンネルへのブロードキャスト通知（`Notifier`）とは異なり、
+/// 特定の予約者への直接的なやり取り（Slack DM等）を前提とするため別ポートとする。
+/// 知らせたあとどうするか（解放するか、そのまま使うか）は本人が決めることであり、
+/// このポートは知らせることにのみ責務を持つ。
+#[async_trait]
+pub trait IdleReservationNotifier: Send + Sync {
+    /// 使われていない予約について予約者へ知らせる
+    async fn notify_idle(&self, idle: IdleReservation) -> Result<(), NotificationError>;
+}

--- a/src/domain/ports/mod.rs
+++ b/src/domain/ports/mod.rs
@@ -20,6 +20,8 @@
 
 /// ポート共通のエラー定義
 pub mod error;
+/// 使われていない予約の通知ポート
+pub mod idle_reservation_notifier;
 /// 通知サービスポート
 pub mod notifier;
 /// リポジトリポート
@@ -34,6 +36,7 @@ pub mod resource_usage_observer;
 pub mod unauthorized_usage_notifier;
 
 pub use error::PortError;
+pub use idle_reservation_notifier::{IdleReservation, IdleReservationNotifier};
 pub use notifier::{NotificationError, NotificationEvent, Notifier};
 pub use reservation_proposal::{ReservationProposal, ReservationProposalNotifier};
 pub use resource_collection_access::{

--- a/src/infrastructure/config/app_config.rs
+++ b/src/infrastructure/config/app_config.rs
@@ -32,6 +32,10 @@ pub struct AppConfig {
     pub unreserved_usage_threshold_secs: u64,
     /// 事後予約提案で提示する利用時間の候補
     pub reservation_proposal_duration_candidates: Vec<Duration>,
+    /// 予約者本人に使われていない予約を知らせるまでの時間（秒）
+    ///
+    /// 残り時間がこれに満たない予約には知らせない（急かしても開けられる時間がないため）。
+    pub idle_reservation_threshold_secs: u64,
     /// MCPサーバーのHTTP/SSEリッスンアドレス（未設定ならMCP機能を無効化）
     pub mcp_listen_addr: Option<SocketAddr>,
     /// MCPアクセストークンファイルのパス

--- a/src/infrastructure/config/defaults.rs
+++ b/src/infrastructure/config/defaults.rs
@@ -24,6 +24,9 @@ pub const GPU_USAGE_MAX_STALENESS_SECS: u64 = 300;
 /// 未予約利用を提案対象とみなす継続時間の閾値のデフォルト値（秒）
 pub const UNRESERVED_USAGE_THRESHOLD_SECS: u64 = 600;
 
+/// 予約が使われていないと知らせるまでの時間のデフォルト値（秒）
+pub const IDLE_RESERVATION_THRESHOLD_SECS: u64 = 1800;
+
 /// 事後予約提案で提示する利用時間候補のデフォルト値（時間、カンマ区切り）
 pub const RESERVATION_PROPOSAL_DURATION_CANDIDATES_HOURS: &str = "1,2,3,5,8";
 

--- a/src/infrastructure/config/loader.rs
+++ b/src/infrastructure/config/loader.rs
@@ -84,6 +84,18 @@ pub fn load_from_env() -> Result<AppConfig, ConfigLoadError> {
         .transpose()?
         .unwrap_or(defaults::UNRESERVED_USAGE_THRESHOLD_SECS);
 
+    let idle_reservation_threshold_secs = env::var("IDLE_RESERVATION_THRESHOLD_SECS")
+        .ok()
+        .map(|s| {
+            s.parse::<u64>()
+                .map_err(|_| ConfigLoadError::InvalidEnvVar {
+                    name: "IDLE_RESERVATION_THRESHOLD_SECS",
+                    reason: "正の整数である必要があります".to_string(),
+                })
+        })
+        .transpose()?
+        .unwrap_or(defaults::IDLE_RESERVATION_THRESHOLD_SECS);
+
     let reservation_proposal_duration_candidates =
         env::var("RESERVATION_PROPOSAL_DURATION_CANDIDATES_HOURS")
             .ok()
@@ -134,6 +146,7 @@ pub fn load_from_env() -> Result<AppConfig, ConfigLoadError> {
         gpu_usage_max_staleness_secs,
         unreserved_usage_threshold_secs,
         reservation_proposal_duration_candidates,
+        idle_reservation_threshold_secs,
         mcp_listen_addr,
         mcp_tokens_file,
         mcp_allowed_hosts,

--- a/src/infrastructure/idle_reservation_notifier/mock.rs
+++ b/src/infrastructure/idle_reservation_notifier/mock.rs
@@ -1,0 +1,50 @@
+use crate::domain::ports::idle_reservation_notifier::{IdleReservation, IdleReservationNotifier};
+use crate::domain::ports::notifier::NotificationError;
+use async_trait::async_trait;
+use std::sync::{Arc, Mutex};
+
+/// テスト/開発用の記録専用実装
+///
+/// 送信内容を標準出力に表示しつつ、テストからの検証用に内部へ保持する。
+#[derive(Clone, Default)]
+pub struct MockIdleReservationNotifier {
+    notices: Arc<Mutex<Vec<IdleReservation>>>,
+    fails: Arc<Mutex<bool>>,
+}
+
+impl MockIdleReservationNotifier {
+    /// 新しいモック実装を作成
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// これまでに送信された通知の一覧を取得
+    pub fn sent_notices(&self) -> Vec<IdleReservation> {
+        self.notices.lock().unwrap().clone()
+    }
+
+    /// 以降の送信を失敗させるかどうかを切り替える
+    pub fn set_failing(&self, failing: bool) {
+        *self.fails.lock().unwrap() = failing;
+    }
+}
+
+#[async_trait]
+impl IdleReservationNotifier for MockIdleReservationNotifier {
+    async fn notify_idle(&self, idle: IdleReservation) -> Result<(), NotificationError> {
+        if *self.fails.lock().unwrap() {
+            return Err(NotificationError::SendFailure(
+                "test induced failure".to_string(),
+            ));
+        }
+
+        println!(
+            "📤 [MockIdleReservationNotifier] {} の予約 {} が {} から使われていない",
+            idle.reservation().owner_email().as_str(),
+            idle.reservation().id().as_str(),
+            idle.idle_since()
+        );
+        self.notices.lock().unwrap().push(idle);
+        Ok(())
+    }
+}

--- a/src/infrastructure/idle_reservation_notifier/mod.rs
+++ b/src/infrastructure/idle_reservation_notifier/mod.rs
@@ -1,0 +1,5 @@
+//! 使われていない予約の通知実装
+
+mod mock;
+
+pub use mock::MockIdleReservationNotifier;

--- a/src/infrastructure/mod.rs
+++ b/src/infrastructure/mod.rs
@@ -12,6 +12,7 @@
 //! Infrastructure層はDomain層とApplication層に依存できる。
 //! 外部サービス（GoogleカレンダーAPI、Slack等）との統合を担当する。
 pub mod config;
+pub mod idle_reservation_notifier;
 pub mod notifier;
 pub mod repositories;
 pub mod reservation_proposal;


### PR DESCRIPTION
A reservation is a promise to use something, and one that nobody is using
makes others wait for time that is in fact free. Nothing was watching for
that, so the only way it surfaced was someone asking in the channel.

The check runs against the owner's own processes: someone else working on
the reserved GPU is unauthorized usage, which the reconcile pass already
tells that person about, and it does not make the reservation used.

Cases the check refuses to judge, rather than guess: servers whose reports
are missing or stale, owners whose OS username is not linked, and rooms.
Reservations with less time left than the threshold are left alone, since
there would be almost nothing to release.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EP2XesjWRdQ7EKhRmhEcb7

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>