### PR TITLE
refactor: hand the bot its dependencies as two bundles

### DIFF
--- a/src/bin/lab-resource-manager.rs
+++ b/src/bin/lab-resource-manager.rs
@@ -36,7 +36,7 @@ use lab_resource_manager::{
         unauthorized_usage_notifier::SlackUnauthorizedUsageNotifier,
     },
     interface::mcp::{self, server::LrmMcpServer},
-    interface::slack::SlackApp,
+    interface::slack::{SlackApp, SlackRepositories, SlackUseCases},
 };
 use slack_morphism::prelude::*;
 use std::sync::Arc;
@@ -279,16 +279,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let app = Arc::new(SlackApp::new(
         app_config,
         resource_config,
-        identity_repo,
-        mcp_token_repo.clone(),
-        grant_access_usecase,
-        create_usecase,
-        accept_proposal_usecase,
-        update_usecase,
-        delete_usecase,
-        release_early_usecase,
-        check_availability_usecase,
-        notify_usecase,
+        SlackRepositories {
+            identity_link: identity_repo,
+            mcp_token: mcp_token_repo.clone(),
+        },
+        SlackUseCases {
+            grant_access: grant_access_usecase,
+            create_resource_usage: create_usecase,
+            accept_reservation_proposal: accept_proposal_usecase,
+            update_resource_usage: update_usecase,
+            delete_resource_usage: delete_usecase,
+            release_resource_usage_early: release_early_usecase,
+            check_resource_availability: check_availability_usecase,
+            notify_resource_usage_changes: notify_usecase,
+        },
         idle_notices,
         slack_client,
         bot_token,

--- a/src/interface/slack/app.rs
+++ b/src/interface/slack/app.rs
@@ -3,19 +3,10 @@
 //! 依存関係を管理し、Slackインタラクションのメインエントリポイントを提供
 
 use crate::application::idle_notice_log::IdleNoticeLog;
-use crate::application::usecases::accept_reservation_proposal::AcceptReservationProposalUseCase;
-use crate::application::usecases::check_resource_availability::CheckResourceAvailabilityUseCase;
-use crate::application::usecases::create_resource_usage::CreateResourceUsageUseCase;
-use crate::application::usecases::delete_resource_usage::DeleteResourceUsageUseCase;
-use crate::application::usecases::grant_user_resource_access::GrantUserResourceAccessUseCase;
-use crate::application::usecases::notify_future_resource_usage_changes::NotifyFutureResourceUsageChangesUseCase;
-use crate::application::usecases::release_resource_usage_early::ReleaseResourceUsageEarlyUseCase;
-use crate::application::usecases::update_resource_usage::UpdateResourceUsageUseCase;
 use crate::domain::ports::notifier::Notifier;
-use crate::domain::ports::repositories::{
-    IdentityLinkRepository, McpTokenRepository, ResourceUsageRepository,
-};
+use crate::domain::ports::repositories::ResourceUsageRepository;
 use crate::infrastructure::config::{AppConfig, ResourceConfig};
+use crate::interface::slack::dependencies::{SlackRepositories, SlackUseCases};
 use slack_morphism::prelude::*;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
@@ -36,22 +27,12 @@ where
     app_config: AppConfig,
     resource_config: Arc<ResourceConfig>,
 
-    // UseCases
-    grant_access_usecase: Arc<GrantUserResourceAccessUseCase>,
-    create_resource_usage_usecase: Arc<CreateResourceUsageUseCase<R>>,
-    accept_reservation_proposal_usecase: Arc<AcceptReservationProposalUseCase<R>>,
-    update_resource_usage_usecase: Arc<UpdateResourceUsageUseCase<R>>,
-    delete_usage_usecase: Arc<DeleteResourceUsageUseCase<R>>,
-    release_early_usecase: Arc<ReleaseResourceUsageEarlyUseCase<R>>,
-    check_availability_usecase: Arc<CheckResourceAvailabilityUseCase<R>>,
-    notify_usecase: Arc<NotifyFutureResourceUsageChangesUseCase<R, N>>,
+    // 依存
+    usecases: SlackUseCases<R, N>,
+    repositories: SlackRepositories,
 
     // 予約者の応答で更新される、未使用予約のお知らせの抑制記録
     idle_notices: Arc<IdleNoticeLog>,
-
-    // リポジトリ
-    identity_repo: Arc<dyn IdentityLinkRepository>,
-    mcp_token_repo: Arc<dyn McpTokenRepository>,
 
     // Slackインフラストラクチャ
     slack_client: Arc<SlackHyperClient>,
@@ -72,20 +53,11 @@ where
     ///
     /// すべての依存関係をコンストラクタで受け取ります（Dependency Injection）。
     /// 内部状態（user_channel_map, task_tracker, http_client）はコンストラクタ内で生成します。
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         app_config: AppConfig,
         resource_config: Arc<ResourceConfig>,
-        identity_repo: Arc<dyn IdentityLinkRepository>,
-        mcp_token_repo: Arc<dyn McpTokenRepository>,
-        grant_access_usecase: Arc<GrantUserResourceAccessUseCase>,
-        create_resource_usage_usecase: Arc<CreateResourceUsageUseCase<R>>,
-        accept_reservation_proposal_usecase: Arc<AcceptReservationProposalUseCase<R>>,
-        update_resource_usage_usecase: Arc<UpdateResourceUsageUseCase<R>>,
-        delete_usage_usecase: Arc<DeleteResourceUsageUseCase<R>>,
-        release_early_usecase: Arc<ReleaseResourceUsageEarlyUseCase<R>>,
-        check_availability_usecase: Arc<CheckResourceAvailabilityUseCase<R>>,
-        notify_usecase: Arc<NotifyFutureResourceUsageChangesUseCase<R, N>>,
+        repositories: SlackRepositories,
+        usecases: SlackUseCases<R, N>,
         idle_notices: Arc<IdleNoticeLog>,
         slack_client: Arc<SlackHyperClient>,
         bot_token: SlackApiToken,
@@ -93,16 +65,8 @@ where
         Self {
             app_config,
             resource_config,
-            identity_repo,
-            mcp_token_repo,
-            grant_access_usecase,
-            create_resource_usage_usecase,
-            accept_reservation_proposal_usecase,
-            update_resource_usage_usecase,
-            delete_usage_usecase,
-            release_early_usecase,
-            check_availability_usecase,
-            notify_usecase,
+            repositories,
+            usecases,
             idle_notices,
             slack_client,
             bot_token,
@@ -152,7 +116,7 @@ where
 
         // バックグラウンドでポーリングタスクを実行
         let polling_handle = {
-            let notify_usecase = self.notify_usecase.clone();
+            let notify_usecase = self.usecases.notify_resource_usage_changes.clone();
             let polling_interval = Duration::from_secs(self.app_config.polling_interval_secs);
             tokio::spawn(async move {
                 loop {
@@ -319,40 +283,12 @@ where
         &self.resource_config
     }
 
-    pub fn identity_repo(&self) -> &Arc<dyn IdentityLinkRepository> {
-        &self.identity_repo
+    pub fn repositories(&self) -> &SlackRepositories {
+        &self.repositories
     }
 
-    pub fn mcp_token_repo(&self) -> &Arc<dyn McpTokenRepository> {
-        &self.mcp_token_repo
-    }
-
-    pub fn grant_access_usecase(&self) -> &Arc<GrantUserResourceAccessUseCase> {
-        &self.grant_access_usecase
-    }
-
-    pub fn create_resource_usage_usecase(&self) -> &Arc<CreateResourceUsageUseCase<R>> {
-        &self.create_resource_usage_usecase
-    }
-
-    pub fn accept_reservation_proposal_usecase(&self) -> &Arc<AcceptReservationProposalUseCase<R>> {
-        &self.accept_reservation_proposal_usecase
-    }
-
-    pub fn update_resource_usage_usecase(&self) -> &Arc<UpdateResourceUsageUseCase<R>> {
-        &self.update_resource_usage_usecase
-    }
-
-    pub fn delete_usage_usecase(&self) -> &Arc<DeleteResourceUsageUseCase<R>> {
-        &self.delete_usage_usecase
-    }
-
-    pub fn release_early_usecase(&self) -> &Arc<ReleaseResourceUsageEarlyUseCase<R>> {
-        &self.release_early_usecase
-    }
-
-    pub fn check_availability_usecase(&self) -> &Arc<CheckResourceAvailabilityUseCase<R>> {
-        &self.check_availability_usecase
+    pub fn usecases(&self) -> &SlackUseCases<R, N> {
+        &self.usecases
     }
 
     pub fn idle_notices(&self) -> &Arc<IdleNoticeLog> {

--- a/src/interface/slack/block_actions/accept_proposal_button.rs
+++ b/src/interface/slack/block_actions/accept_proposal_button.rs
@@ -169,8 +169,12 @@ where
         return format!("❌ 予約の作成に失敗しました: {}", failure);
     };
 
-    let detail =
-        conflict_message::build(conflicts, app.resource_config(), app.identity_repo()).await;
+    let detail = conflict_message::build(
+        conflicts,
+        app.resource_config(),
+        &app.repositories().identity_link,
+    )
+    .await;
 
     if conflicts_only_with_own_reservations(conflicts, accepted_by) {
         format!(
@@ -203,7 +207,8 @@ where
     let resources = resolve_gpu_resources(app, &payload.server, &payload.device_numbers)?;
     let owner_email = EmailAddress::new(payload.owner_email)?;
 
-    app.accept_reservation_proposal_usecase()
+    app.usecases()
+        .accept_reservation_proposal
         .execute(
             owner_email.clone(),
             resources,

--- a/src/interface/slack/block_actions/cancel_button.rs
+++ b/src/interface/slack/block_actions/cancel_button.rs
@@ -41,8 +41,8 @@ where
     }
 
     // 依存性を取得
-    let delete_usage_usecase = app.delete_usage_usecase();
-    let identity_repo = app.identity_repo();
+    let delete_usage_usecase = &app.usecases().delete_resource_usage;
+    let identity_repo = &app.repositories().identity_link;
 
     // ユーザーのメールアドレスを取得
     let owner_email = user_resolver::resolve_user_email(&user.id, identity_repo).await?;

--- a/src/interface/slack/block_actions/edit_button.rs
+++ b/src/interface/slack/block_actions/edit_button.rs
@@ -33,7 +33,7 @@ where
     // 依存性を取得
     let slack_client = app.slack_client();
     let bot_token = app.bot_token();
-    let identity_repo = app.identity_repo();
+    let identity_repo = &app.repositories().identity_link;
     let config = app.resource_config();
 
     let trigger_id = &block_actions.trigger_id;

--- a/src/interface/slack/block_actions/idle_reservation_buttons.rs
+++ b/src/interface/slack/block_actions/idle_reservation_buttons.rs
@@ -44,7 +44,8 @@ where
         ACTION_IDLE_KEEP => keep(app, &usage_id),
         ACTION_IDLE_RELEASE | ACTION_IDLE_CANCEL => {
             let requested_by = EmailAddress::new(
-                user_resolver::resolve_user_email(&user.id, app.identity_repo()).await?,
+                user_resolver::resolve_user_email(&user.id, &app.repositories().identity_link)
+                    .await?,
             )?;
 
             if action_id == ACTION_IDLE_RELEASE {
@@ -98,7 +99,8 @@ where
     );
 
     match app
-        .release_early_usecase()
+        .usecases()
+        .release_resource_usage_early
         .execute(usage_id, requested_by)
         .await
     {
@@ -136,7 +138,8 @@ where
     );
 
     match app
-        .delete_usage_usecase()
+        .usecases()
+        .delete_resource_usage
         .execute(usage_id, requested_by)
         .await
     {

--- a/src/interface/slack/block_actions/release_early_button.rs
+++ b/src/interface/slack/block_actions/release_early_button.rs
@@ -37,8 +37,9 @@ where
         return Ok(());
     };
 
-    let requested_by =
-        EmailAddress::new(user_resolver::resolve_user_email(&user.id, app.identity_repo()).await?)?;
+    let requested_by = EmailAddress::new(
+        user_resolver::resolve_user_email(&user.id, &app.repositories().identity_link).await?,
+    )?;
     let usage_id = UsageId::from_string(usage_id_str.to_string());
 
     info!(
@@ -49,7 +50,8 @@ where
     );
 
     let outcome = app
-        .release_early_usecase()
+        .usecases()
+        .release_resource_usage_early
         .execute(&usage_id, &requested_by)
         .await;
 

--- a/src/interface/slack/dependencies.rs
+++ b/src/interface/slack/dependencies.rs
@@ -1,0 +1,56 @@
+//! Slackボットが必要とする依存
+//!
+//! ボットが呼び出すユースケースと参照するリポジトリを、それぞれひとつの束として扱います。
+//!
+//! ## 束ねる理由
+//!
+//! これらは常に一緒に組み立てられ、一緒に`SlackApp`へ渡ります。個別の引数として
+//! 並べると、機能をひとつ足すたびにフィールド・引数・初期化・アクセサ・
+//! コンポジションルートの5箇所を触ることになり、追加のたびに同じ場所を
+//! 編集し続けることになります。束にすれば、触るのは束の定義と組み立て側の2箇所です。
+
+use crate::application::usecases::{
+    AcceptReservationProposalUseCase, CheckResourceAvailabilityUseCase, CreateResourceUsageUseCase,
+    DeleteResourceUsageUseCase, GrantUserResourceAccessUseCase,
+    NotifyFutureResourceUsageChangesUseCase, ReleaseResourceUsageEarlyUseCase,
+    UpdateResourceUsageUseCase,
+};
+use crate::domain::ports::notifier::Notifier;
+use crate::domain::ports::repositories::{
+    IdentityLinkRepository, McpTokenRepository, ResourceUsageRepository,
+};
+use std::sync::Arc;
+
+/// Slackボットが呼び出すユースケース
+pub struct SlackUseCases<R, N>
+where
+    R: ResourceUsageRepository,
+    N: Notifier,
+{
+    /// リソースへのアクセス権を付与する
+    pub grant_access: Arc<GrantUserResourceAccessUseCase>,
+    /// 予約を作成する
+    pub create_resource_usage: Arc<CreateResourceUsageUseCase<R>>,
+    /// 事後予約の提案を受諾する
+    pub accept_reservation_proposal: Arc<AcceptReservationProposalUseCase<R>>,
+    /// 予約を更新する
+    pub update_resource_usage: Arc<UpdateResourceUsageUseCase<R>>,
+    /// 予約を取り消す
+    pub delete_resource_usage: Arc<DeleteResourceUsageUseCase<R>>,
+    /// 進行中の予約を今の時点で締める
+    pub release_resource_usage_early: Arc<ReleaseResourceUsageEarlyUseCase<R>>,
+    /// リソースの空きを調べる
+    pub check_resource_availability: Arc<CheckResourceAvailabilityUseCase<R>>,
+    /// 予約の変更を監視して通知する
+    pub notify_resource_usage_changes: Arc<NotifyFutureResourceUsageChangesUseCase<R, N>>,
+}
+
+/// Slackボットが参照するリポジトリ
+///
+/// 予約リポジトリはユースケースの内側にあるため、ここには現れない。
+pub struct SlackRepositories {
+    /// 識別情報とメールアドレスの紐付け
+    pub identity_link: Arc<dyn IdentityLinkRepository>,
+    /// MCPアクセストークン
+    pub mcp_token: Arc<dyn McpTokenRepository>,
+}

--- a/src/interface/slack/mod.rs
+++ b/src/interface/slack/mod.rs
@@ -11,6 +11,7 @@
 //! ### モジュール構成
 //!
 //! - `app`: 依存性注入を備えたアプリケーションコア
+//! - `dependencies`: ボットが必要とするユースケースとリポジトリの束
 //! - `gateway`: Slackイベントのルーティング（イベント種別に応じたハンドラへの振り分け）
 //! - `slash_commands`: スラッシュコマンドハンドラ（`/register-calendar`、`/link-user`）
 //! - `block_actions`: ブロックアクションハンドラ（モーダル内ボタンクリックなど）
@@ -35,6 +36,7 @@ pub mod app;
 pub mod async_execution;
 pub mod block_actions;
 pub mod constants;
+pub mod dependencies;
 pub mod gateway;
 pub mod slack_client;
 pub mod slash_commands;
@@ -44,3 +46,4 @@ pub mod views;
 
 // 主要な型を再エクスポート
 pub use app::SlackApp;
+pub use dependencies::{SlackRepositories, SlackUseCases};

--- a/src/interface/slack/slash_commands/free.rs
+++ b/src/interface/slack/slash_commands/free.rs
@@ -42,7 +42,8 @@ where
 
     let resources = app.resource_config().all_resources();
     let availabilities = app
-        .check_availability_usecase()
+        .usecases()
+        .check_resource_availability
         .execute(&resources, &window)
         .await?;
 
@@ -57,7 +58,8 @@ where
         "reporting resource availability"
     );
 
-    let owner_displays = resolve_owner_displays(&availabilities, now, app.identity_repo()).await;
+    let owner_displays =
+        resolve_owner_displays(&availabilities, now, &app.repositories().identity_link).await;
     let timezone = display_timezone(app.resource_config());
 
     let content =

--- a/src/interface/slack/slash_commands/mcp_token.rs
+++ b/src/interface/slack/slash_commands/mcp_token.rs
@@ -23,8 +23,11 @@ where
 {
     debug!(user = %event.user_id, "issuing an mcp token");
 
-    let email_str = match user_resolver::resolve_user_email(&event.user_id, app.identity_repo())
-        .await
+    let email_str = match user_resolver::resolve_user_email(
+        &event.user_id,
+        &app.repositories().identity_link,
+    )
+    .await
     {
         Ok(email) => email,
         Err(e) => {
@@ -40,7 +43,7 @@ where
 
     let email = EmailAddress::new(email_str)?;
 
-    let token = app.mcp_token_repo().issue_token(&email).await?;
+    let token = app.repositories().mcp_token.issue_token(&email).await?;
 
     info!(owner = %email.as_str(), "mcp token issued");
 

--- a/src/interface/slack/slash_commands/reserve.rs
+++ b/src/interface/slack/slash_commands/reserve.rs
@@ -27,7 +27,7 @@ where
     let config = app.resource_config();
     let slack_client = app.slack_client();
     let bot_token = app.bot_token();
-    let identity_repo = app.identity_repo();
+    let identity_repo = &app.repositories().identity_link;
 
     // Check if user is linked
     let is_linked = user_resolver::is_user_linked(user_id, identity_repo).await;

--- a/src/interface/slack/view_submissions/link_user.rs
+++ b/src/interface/slack/view_submissions/link_user.rs
@@ -91,7 +91,8 @@ where
     // ユーザーをリンク
     let link_result = match &email_result {
         Ok(email) => app
-            .grant_access_usecase()
+            .usecases()
+            .grant_access
             .execute(
                 link_target.external_system.clone(),
                 link_target.external_user_id.clone(),

--- a/src/interface/slack/view_submissions/registration.rs
+++ b/src/interface/slack/view_submissions/registration.rs
@@ -32,7 +32,8 @@ where
 
     let registration_result = match &email_result {
         Ok(email) => app
-            .grant_access_usecase()
+            .usecases()
+            .grant_access
             .execute(ExternalSystem::Slack, user_id.to_string(), email.clone())
             .await
             .map_err(|e| e.into()),

--- a/src/interface/slack/view_submissions/reserve.rs
+++ b/src/interface/slack/view_submissions/reserve.rs
@@ -25,8 +25,8 @@ where
     let user_id = view_submission.user.id.clone();
 
     // Get dependencies
-    let create_usage_usecase = app.create_resource_usage_usecase();
-    let identity_repo = app.identity_repo();
+    let create_usage_usecase = &app.usecases().create_resource_usage;
+    let identity_repo = &app.repositories().identity_link;
     let config = app.resource_config();
 
     // Extract form values

--- a/src/interface/slack/view_submissions/update.rs
+++ b/src/interface/slack/view_submissions/update.rs
@@ -53,7 +53,8 @@ where
 
     // ユーザーのメールアドレスを取得
     let identity_link = app
-        .identity_repo()
+        .repositories()
+        .identity_link
         .find_by_external_user_id(&ExternalSystem::Slack, user_id.as_ref())
         .await?
         .ok_or("ユーザーが登録されていません。まず /register-calendar を実行してください")?;
@@ -62,7 +63,8 @@ where
 
     // 予約を更新
     let update_result = app
-        .update_resource_usage_usecase()
+        .usecases()
+        .update_resource_usage
         .execute(&usage_id, &owner_email, Some(time_period), notes)
         .await;
 
@@ -79,9 +81,12 @@ where
     let message_text = match update_result {
         Ok(_) => "✅ 予約を更新しました".to_string(),
         Err(ApplicationError::ResourceConflict { conflicts }) => {
-            let conflict_detail =
-                conflict_message::build(&conflicts, app.resource_config(), app.identity_repo())
-                    .await;
+            let conflict_detail = conflict_message::build(
+                &conflicts,
+                app.resource_config(),
+                &app.repositories().identity_link,
+            )
+            .await;
             format!("❌ 予約の更新に失敗しました\n\n{}", conflict_detail)
         }
         Err(e) => {


### PR DESCRIPTION
Adding one use case to the bot meant touching five places: the field, the
constructor parameter, the initializer, the accessor, and the composition root.
The constructor had reached thirteen parameters and carried an
`#[allow(clippy::too_many_arguments)]` to stay quiet about it. Every feature paid
that tax, and this branch had just paid it twice.

The things that are always built together and always handed over together become
two bundles: `SlackUseCases` for what the bot calls, and `SlackRepositories` for
what it reads. The constructor takes six parameters and the allow attribute is
gone. Adding a use case now means touching the bundle and the composition root.

Call sites read one level deeper and one word shorter:

    app.identity_repo()                  ->  &app.repositories().identity_link
    app.create_resource_usage_usecase()  ->  &app.usecases().create_resource_usage

The bundles are plain structs with public fields and no behaviour. Their job is to
carry dependencies across one boundary, and wrapping them in accessors would only
push callers further from what they came for. The `_usecase` and `_repo` suffixes
are dropped because the bundle name already says which kind it is.

The idle-notice log stays a separate field. It is neither a use case nor a
repository, and folding it into either bundle would make that bundle mean less.

Behaviour is unchanged; the existing tests pass as they are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139999bP7ect6rVYU4caLPw