### PR TITLE
refactor: send every direct message through one place

### DIFF
--- a/src/infrastructure/idle_reservation_notifier/slack.rs
+++ b/src/infrastructure/idle_reservation_notifier/slack.rs
@@ -1,13 +1,12 @@
 //! Slack DM経由の未使用予約の通知実装
 
-use crate::domain::aggregates::identity_link::value_objects::ExternalSystem;
 use crate::domain::aggregates::resource_usage::entity::ResourceUsage;
-use crate::domain::common::EmailAddress;
 use crate::domain::ports::idle_reservation_notifier::{IdleReservation, IdleReservationNotifier};
 use crate::domain::ports::notifier::NotificationError;
 use crate::domain::ports::repositories::IdentityLinkRepository;
 use crate::infrastructure::config::{DateFormat, ResourceStyle, TimeStyle};
 use crate::infrastructure::notifier::formatter::{format_resources_styled, format_time_styled};
+use crate::infrastructure::slack_direct_message::SlackDirectMessenger;
 use async_trait::async_trait;
 use chrono::{DateTime, Local, Utc};
 use slack_morphism::prelude::*;
@@ -20,9 +19,7 @@ use crate::interface::slack::constants::{
 
 /// Slack DM経由で未使用の予約を予約者へ知らせる実装
 pub struct SlackIdleReservationNotifier {
-    slack_client: Arc<SlackHyperClient>,
-    bot_token: SlackApiToken,
-    identity_repo: Arc<dyn IdentityLinkRepository>,
+    messenger: SlackDirectMessenger,
 }
 
 impl SlackIdleReservationNotifier {
@@ -33,41 +30,8 @@ impl SlackIdleReservationNotifier {
         identity_repo: Arc<dyn IdentityLinkRepository>,
     ) -> Self {
         Self {
-            slack_client,
-            bot_token,
-            identity_repo,
+            messenger: SlackDirectMessenger::new(slack_client, bot_token, identity_repo),
         }
-    }
-
-    /// 予約者のSlackユーザーIDを解決する
-    async fn resolve_slack_user_id(
-        &self,
-        owner_email: &EmailAddress,
-    ) -> Result<SlackUserId, NotificationError> {
-        let identity_link = self
-            .identity_repo
-            .find_by_email(owner_email)
-            .await
-            .map_err(|e| {
-                NotificationError::RepositoryError(format!("IdentityLink取得失敗: {}", e))
-            })?
-            .ok_or_else(|| {
-                NotificationError::SendFailure(format!(
-                    "IdentityLink未登録のためDMを送信できません: {}",
-                    owner_email.as_str()
-                ))
-            })?;
-
-        let slack_identity = identity_link
-            .get_identity_for_system(&ExternalSystem::Slack)
-            .ok_or_else(|| {
-                NotificationError::SendFailure(format!(
-                    "Slackアカウント未リンクのためDMを送信できません: {}",
-                    owner_email.as_str()
-                ))
-            })?;
-
-        Ok(SlackUserId::new(slack_identity.user_id().to_string()))
     }
 }
 
@@ -75,35 +39,13 @@ impl SlackIdleReservationNotifier {
 impl IdleReservationNotifier for SlackIdleReservationNotifier {
     async fn notify_idle(&self, idle: IdleReservation) -> Result<(), NotificationError> {
         let reservation = idle.reservation();
-        let slack_user_id = self
-            .resolve_slack_user_id(reservation.owner_email())
-            .await?;
-
-        let session = self.slack_client.open_session(&self.bot_token);
-
-        let open_resp = session
-            .conversations_open(
-                &SlackApiConversationsOpenRequest::new().with_users(vec![slack_user_id]),
-            )
-            .await
-            .map_err(|e| {
-                NotificationError::SendFailure(format!("DMチャンネルのオープンに失敗: {}", e))
-            })?;
-
         let text = build_idle_message(reservation, idle.idle_since());
         let blocks = build_idle_blocks(reservation, &text);
 
-        let post_req = SlackApiChatPostMessageRequest::new(
-            open_resp.channel.id,
-            SlackMessageContent::new()
-                .with_text(text)
-                .with_blocks(blocks),
-        );
-
-        let sent = session
-            .chat_post_message(&post_req)
-            .await
-            .map_err(|e| NotificationError::SendFailure(format!("Slack DM送信失敗: {}", e)))?;
+        let sent = self
+            .messenger
+            .send(reservation.owner_email(), text, blocks)
+            .await?;
 
         tracing::info!(
             channel = %sent.channel,
@@ -194,6 +136,7 @@ fn build_idle_blocks(reservation: &ResourceUsage, text: &str) -> Vec<SlackBlock>
 mod tests {
     use super::*;
     use crate::domain::aggregates::resource_usage::value_objects::{Gpu, Resource, TimePeriod};
+    use crate::domain::common::EmailAddress;
     use chrono::Duration;
 
     fn sample_reservation() -> ResourceUsage {

--- a/src/infrastructure/mod.rs
+++ b/src/infrastructure/mod.rs
@@ -18,4 +18,5 @@ pub mod repositories;
 pub mod reservation_proposal;
 pub mod resource_collection_access;
 pub mod resource_usage_observer;
+pub mod slack_direct_message;
 pub mod unauthorized_usage_notifier;

--- a/src/infrastructure/reservation_proposal/slack.rs
+++ b/src/infrastructure/reservation_proposal/slack.rs
@@ -1,6 +1,5 @@
 //! Slack DM経由の事後予約提案実装
 
-use crate::domain::aggregates::identity_link::value_objects::ExternalSystem;
 use crate::domain::aggregates::resource_usage::value_objects::{Gpu, Resource};
 use crate::domain::ports::notifier::NotificationError;
 use crate::domain::ports::repositories::IdentityLinkRepository;
@@ -9,6 +8,7 @@ use crate::domain::ports::reservation_proposal::{
 };
 use crate::infrastructure::config::ResourceStyle;
 use crate::infrastructure::notifier::formatter::format_resources_styled;
+use crate::infrastructure::slack_direct_message::SlackDirectMessenger;
 use async_trait::async_trait;
 use chrono::Duration;
 use serde::{Deserialize, Serialize};
@@ -40,9 +40,7 @@ pub struct ProposalAcceptPayload {
 
 /// Slack DM経由で事後予約を提案する実装
 pub struct SlackReservationProposalNotifier {
-    slack_client: Arc<SlackHyperClient>,
-    bot_token: SlackApiToken,
-    identity_repo: Arc<dyn IdentityLinkRepository>,
+    messenger: SlackDirectMessenger,
 }
 
 impl SlackReservationProposalNotifier {
@@ -53,41 +51,8 @@ impl SlackReservationProposalNotifier {
         identity_repo: Arc<dyn IdentityLinkRepository>,
     ) -> Self {
         Self {
-            slack_client,
-            bot_token,
-            identity_repo,
+            messenger: SlackDirectMessenger::new(slack_client, bot_token, identity_repo),
         }
-    }
-
-    /// 提案先のSlackユーザーIDを解決する
-    async fn resolve_slack_user_id(
-        &self,
-        proposal: &ReservationProposal,
-    ) -> Result<SlackUserId, NotificationError> {
-        let identity_link = self
-            .identity_repo
-            .find_by_email(proposal.owner_email())
-            .await
-            .map_err(|e| {
-                NotificationError::RepositoryError(format!("IdentityLink取得失敗: {}", e))
-            })?
-            .ok_or_else(|| {
-                NotificationError::SendFailure(format!(
-                    "IdentityLink未登録のためDMを送信できません: {}",
-                    proposal.owner_email().as_str()
-                ))
-            })?;
-
-        let slack_identity = identity_link
-            .get_identity_for_system(&ExternalSystem::Slack)
-            .ok_or_else(|| {
-                NotificationError::SendFailure(format!(
-                    "Slackアカウント未リンクのためDMを送信できません: {}",
-                    proposal.owner_email().as_str()
-                ))
-            })?;
-
-        Ok(SlackUserId::new(slack_identity.user_id().to_string()))
     }
 }
 
@@ -96,36 +61,16 @@ impl ReservationProposalNotifier for SlackReservationProposalNotifier {
     async fn propose(&self, proposal: ReservationProposal) -> Result<(), NotificationError> {
         let gpus = collect_gpus(&proposal)?;
 
-        let slack_user_id = self.resolve_slack_user_id(&proposal).await?;
-
-        let session = self.slack_client.open_session(&self.bot_token);
-
-        let open_resp = session
-            .conversations_open(
-                &SlackApiConversationsOpenRequest::new().with_users(vec![slack_user_id]),
-            )
-            .await
-            .map_err(|e| {
-                NotificationError::SendFailure(format!("DMチャンネルのオープンに失敗: {}", e))
-            })?;
-
         let text = format!(
             "⏱️ 予約なしでリソースを使用しています\n\n💻 使用中のリソース\n{}\n\nこのまま事後予約を作成しますか？",
             format_resources_styled(proposal.resources(), ResourceStyle::Full)
         );
         let blocks = build_proposal_blocks(&proposal, &gpus, &text);
 
-        let post_req = SlackApiChatPostMessageRequest::new(
-            open_resp.channel.id,
-            SlackMessageContent::new()
-                .with_text(text)
-                .with_blocks(blocks),
-        );
-
-        let sent = session
-            .chat_post_message(&post_req)
-            .await
-            .map_err(|e| NotificationError::SendFailure(format!("Slack DM送信失敗: {}", e)))?;
+        let sent = self
+            .messenger
+            .send(proposal.owner_email(), text, blocks)
+            .await?;
 
         tracing::info!(
             channel = %sent.channel,
@@ -242,7 +187,9 @@ fn format_duration_label(duration: Duration) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::aggregates::identity_link::value_objects::ExternalIdentity;
+    use crate::domain::aggregates::identity_link::value_objects::{
+        ExternalIdentity, ExternalSystem,
+    };
     use crate::domain::aggregates::resource_usage::value_objects::Gpu;
     use crate::domain::common::EmailAddress;
     use chrono::Utc;

--- a/src/infrastructure/slack_direct_message.rs
+++ b/src/infrastructure/slack_direct_message.rs
@@ -1,0 +1,120 @@
+//! 本人宛のSlack DM送信
+//!
+//! 予約にまつわる知らせのうち、チャンネルへのブロードキャストではなく本人に直接
+//! 届けるもの（事後予約の提案、無断使用の通知、未使用予約のお知らせ）はここを通る。
+//! 誰に届けるかはメールアドレスで指定し、Slackのユーザーへの読み替えはここで閉じる。
+
+use crate::domain::aggregates::identity_link::value_objects::ExternalSystem;
+use crate::domain::common::EmailAddress;
+use crate::domain::ports::notifier::NotificationError;
+use crate::domain::ports::repositories::IdentityLinkRepository;
+use slack_morphism::prelude::*;
+use std::sync::Arc;
+
+/// 送信できたメッセージの位置
+///
+/// 受け取った側から「この知らせはおかしい」と言われたとき、チャンネルと時刻の組で
+/// 当該メッセージを特定できる。何の知らせだったかは送り手にしか分からないため、
+/// ログに残すのは呼び出し側の仕事とする。
+pub struct SentDirectMessage {
+    pub channel: SlackChannelId,
+    pub ts: SlackTs,
+}
+
+/// メールアドレス宛にSlack DMを送る
+pub struct SlackDirectMessenger {
+    slack_client: Arc<SlackHyperClient>,
+    bot_token: SlackApiToken,
+    identity_repo: Arc<dyn IdentityLinkRepository>,
+}
+
+impl SlackDirectMessenger {
+    /// 新しい送信口を作成
+    pub fn new(
+        slack_client: Arc<SlackHyperClient>,
+        bot_token: SlackApiToken,
+        identity_repo: Arc<dyn IdentityLinkRepository>,
+    ) -> Self {
+        Self {
+            slack_client,
+            bot_token,
+            identity_repo,
+        }
+    }
+
+    /// 本文とブロックを届ける
+    ///
+    /// `blocks`が空ならテキストだけのメッセージとして送る。
+    ///
+    /// # Errors
+    /// 宛先のSlackアカウントが分からない場合、またはSlack APIの呼び出しに失敗した場合
+    pub async fn send(
+        &self,
+        to: &EmailAddress,
+        text: String,
+        blocks: Vec<SlackBlock>,
+    ) -> Result<SentDirectMessage, NotificationError> {
+        let slack_user_id = self.resolve_slack_user_id(to).await?;
+        let session = self.slack_client.open_session(&self.bot_token);
+
+        let opened = session
+            .conversations_open(
+                &SlackApiConversationsOpenRequest::new().with_users(vec![slack_user_id]),
+            )
+            .await
+            .map_err(|e| {
+                NotificationError::SendFailure(format!("DMチャンネルのオープンに失敗: {}", e))
+            })?;
+
+        let content = SlackMessageContent::new().with_text(text);
+        let content = if blocks.is_empty() {
+            content
+        } else {
+            content.with_blocks(blocks)
+        };
+
+        let sent = session
+            .chat_post_message(&SlackApiChatPostMessageRequest::new(
+                opened.channel.id,
+                content,
+            ))
+            .await
+            .map_err(|e| NotificationError::SendFailure(format!("Slack DM送信失敗: {}", e)))?;
+
+        Ok(SentDirectMessage {
+            channel: sent.channel,
+            ts: sent.ts,
+        })
+    }
+
+    /// 宛先のSlackユーザーIDを解決する
+    async fn resolve_slack_user_id(
+        &self,
+        to: &EmailAddress,
+    ) -> Result<SlackUserId, NotificationError> {
+        let identity_link = self
+            .identity_repo
+            .find_by_email(to)
+            .await
+            .map_err(|e| {
+                NotificationError::RepositoryError(format!("IdentityLink取得失敗: {}", e))
+            })?
+            .ok_or_else(|| {
+                NotificationError::SendFailure(format!(
+                    "IdentityLink未登録のためDMを送信できません: {}",
+                    to.as_str()
+                ))
+            })?;
+
+        let slack_identity = identity_link
+            .get_identity_for_system(&ExternalSystem::Slack)
+            .ok_or_else(|| {
+                NotificationError::SendFailure(format!(
+                    "Slackアカウント未リンクのためDMを送信できません: {}",
+                    to.as_str()
+                ))
+            })?;
+
+        Ok(SlackUserId::new(slack_identity.user_id().to_string()))
+    }
+}

--- a/src/infrastructure/unauthorized_usage_notifier/slack.rs
+++ b/src/infrastructure/unauthorized_usage_notifier/slack.rs
@@ -1,6 +1,5 @@
 //! Slack DM経由の無断使用検知通知実装
 
-use crate::domain::aggregates::identity_link::value_objects::ExternalSystem;
 use crate::domain::aggregates::resource_usage::entity::ResourceUsage;
 use crate::domain::common::EmailAddress;
 use crate::domain::ports::notifier::NotificationError;
@@ -8,15 +7,14 @@ use crate::domain::ports::repositories::IdentityLinkRepository;
 use crate::domain::ports::unauthorized_usage_notifier::UnauthorizedUsageNotifier;
 use crate::infrastructure::config::{DateFormat, ResourceStyle, TimeStyle};
 use crate::infrastructure::notifier::formatter::{format_resources_styled, format_time_styled};
+use crate::infrastructure::slack_direct_message::SlackDirectMessenger;
 use async_trait::async_trait;
 use slack_morphism::prelude::*;
 use std::sync::Arc;
 
 /// Slack DM経由で無断使用検知を本人へ通知する実装
 pub struct SlackUnauthorizedUsageNotifier {
-    slack_client: Arc<SlackHyperClient>,
-    bot_token: SlackApiToken,
-    identity_repo: Arc<dyn IdentityLinkRepository>,
+    messenger: SlackDirectMessenger,
 }
 
 impl SlackUnauthorizedUsageNotifier {
@@ -27,41 +25,8 @@ impl SlackUnauthorizedUsageNotifier {
         identity_repo: Arc<dyn IdentityLinkRepository>,
     ) -> Self {
         Self {
-            slack_client,
-            bot_token,
-            identity_repo,
+            messenger: SlackDirectMessenger::new(slack_client, bot_token, identity_repo),
         }
-    }
-
-    /// 通知先（実際の利用者）のSlackユーザーIDを解決する
-    async fn resolve_slack_user_id(
-        &self,
-        actual_user_email: &EmailAddress,
-    ) -> Result<SlackUserId, NotificationError> {
-        let identity_link = self
-            .identity_repo
-            .find_by_email(actual_user_email)
-            .await
-            .map_err(|e| {
-                NotificationError::RepositoryError(format!("IdentityLink取得失敗: {}", e))
-            })?
-            .ok_or_else(|| {
-                NotificationError::SendFailure(format!(
-                    "IdentityLink未登録のためDMを送信できません: {}",
-                    actual_user_email.as_str()
-                ))
-            })?;
-
-        let slack_identity = identity_link
-            .get_identity_for_system(&ExternalSystem::Slack)
-            .ok_or_else(|| {
-                NotificationError::SendFailure(format!(
-                    "Slackアカウント未リンクのためDMを送信できません: {}",
-                    actual_user_email.as_str()
-                ))
-            })?;
-
-        Ok(SlackUserId::new(slack_identity.user_id().to_string()))
     }
 }
 
@@ -72,30 +37,12 @@ impl UnauthorizedUsageNotifier for SlackUnauthorizedUsageNotifier {
         reserved_usage: &ResourceUsage,
         actual_user_email: &EmailAddress,
     ) -> Result<(), NotificationError> {
-        let slack_user_id = self.resolve_slack_user_id(actual_user_email).await?;
-
-        let session = self.slack_client.open_session(&self.bot_token);
-
-        let open_resp = session
-            .conversations_open(
-                &SlackApiConversationsOpenRequest::new().with_users(vec![slack_user_id]),
-            )
-            .await
-            .map_err(|e| {
-                NotificationError::SendFailure(format!("DMチャンネルのオープンに失敗: {}", e))
-            })?;
-
         let text = build_unauthorized_message(reserved_usage);
 
-        let post_req = SlackApiChatPostMessageRequest::new(
-            open_resp.channel.id,
-            SlackMessageContent::new().with_text(text),
-        );
-
-        let sent = session
-            .chat_post_message(&post_req)
-            .await
-            .map_err(|e| NotificationError::SendFailure(format!("Slack DM送信失敗: {}", e)))?;
+        let sent = self
+            .messenger
+            .send(actual_user_email, text, Vec::new())
+            .await?;
 
         tracing::info!(
             channel = %sent.channel,


### PR DESCRIPTION
Three notifiers each carried the same three steps: read the Slack account
off the identity link, open the conversation, post. The third copy arrived
with the idle-reservation notice, so the steps move behind one sender and
the notifiers keep only what differs — what to say.

The constructors keep their signatures, so the composition root is
unchanged.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EP2XesjWRdQ7EKhRmhEcb7

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>