### PR TITLE
fix: forget the anti-spam records once they can no longer apply

### DIFF
--- a/src/application/usecases/reconcile_observed_usages.rs
+++ b/src/application/usecases/reconcile_observed_usages.rs
@@ -163,6 +163,9 @@ where
         let sessions = Self::group_into_sessions(unreserved);
         let session_count = sessions.len();
 
+        self.forget_opportunities_that_ended(&sessions).await;
+        self.forget_reservations_that_ended(&current_usages).await;
+
         for session in sessions {
             if let Err(e) = self.propose_for_session(&session).await {
                 failures += 1;
@@ -182,6 +185,44 @@ where
         );
 
         Ok(())
+    }
+
+    /// 観測から消えた機会についての「提案済み」を忘れる
+    ///
+    /// 使い終わった機会に提案することはもうない。記録を持ち続けても増えていくだけで、
+    /// 同じ機会が戻ってくることもない（使い直せば開始時刻が変わり、別の機会になる）。
+    async fn forget_opportunities_that_ended(&self, sessions: &[Vec<ObservedUsage>]) {
+        let still_running: HashSet<ProposedSessionKey> = sessions
+            .iter()
+            .filter_map(|session| {
+                let first = session.first()?;
+                let resources: Vec<Resource> = session
+                    .iter()
+                    .map(|usage| usage.resource().clone())
+                    .collect();
+                Some(Self::session_key(first, &resources))
+            })
+            .collect();
+
+        self.proposed_keys
+            .lock()
+            .await
+            .retain(|key| still_running.contains(key));
+    }
+
+    /// 終わった予約についての「通知済み」を忘れる
+    ///
+    /// 予約が終われば、その予約を巡って知らせることはもうない。
+    async fn forget_reservations_that_ended(&self, in_progress: &[ResourceUsage]) {
+        let still_running: HashSet<&str> = in_progress
+            .iter()
+            .map(|reservation| reservation.id().as_str())
+            .collect();
+
+        self.notified_unauthorized_keys
+            .lock()
+            .await
+            .retain(|(_, usage_id, _)| still_running.contains(usage_id.as_str()));
     }
 
     /// 未予約の利用を「同じ機会に使い始めた一群」へ分ける

--- a/src/application/usecases/reconcile_observed_usages_tests.rs
+++ b/src/application/usecases/reconcile_observed_usages_tests.rs
@@ -690,3 +690,71 @@ async fn using_gpus_of_two_different_reservations_notifies_for_each() {
         "予約が別なら、それぞれの予約者について知らせるべき"
     );
 }
+
+#[tokio::test]
+async fn an_opportunity_that_ended_is_forgotten() {
+    let (usecase, _repo, observer, identity_repo, proposal_notifier, _notifier) = make_usecase(15);
+    identity_repo.add_link("user@example.com", os_system(), "kkawaguchi");
+
+    let active_since = Utc::now() - Duration::minutes(20);
+    let usage = ObservedUsage::new(
+        gpu_resource(),
+        ExternalIdentity::new(os_system(), "kkawaguchi".to_string()),
+        active_since,
+    );
+
+    observer.set_active_usages(vec![usage.clone()]);
+    usecase.poll_once().await.unwrap();
+    assert_eq!(proposal_notifier.sent_proposals().len(), 1);
+
+    // 使い終わって観測から消える
+    observer.set_active_usages(vec![]);
+    usecase.poll_once().await.unwrap();
+
+    // 同じ機会が観測に戻ることはないが、戻ったとしても記録は残っていない
+    observer.set_active_usages(vec![usage]);
+    usecase.poll_once().await.unwrap();
+
+    assert_eq!(
+        proposal_notifier.sent_proposals().len(),
+        2,
+        "消えた機会の記録を抱え続けない"
+    );
+}
+
+#[tokio::test]
+async fn the_unauthorized_notice_is_forgotten_once_the_reservation_ends() {
+    let (usecase, repo, observer, identity_repo, _proposal_notifier, notifier) = make_usecase(15);
+    identity_repo.add_link("other@example.com", os_system(), "kkawaguchi");
+
+    let now = Utc::now();
+    let reservation = make_reservation(
+        "owner@example.com",
+        now - Duration::hours(1),
+        now + Duration::hours(1),
+    );
+    repo.save(&reservation).await.unwrap();
+
+    observer.set_active_usages(vec![ObservedUsage::new(
+        gpu_resource(),
+        ExternalIdentity::new(os_system(), "kkawaguchi".to_string()),
+        now - Duration::minutes(30),
+    )]);
+
+    usecase.poll_once().await.unwrap();
+    assert_eq!(notifier.notified().len(), 1);
+
+    // 予約が取り消され、進行中の予約がなくなる
+    repo.delete(reservation.id()).await.unwrap();
+    usecase.poll_once().await.unwrap();
+
+    // 同じ予約が戻れば、それは改めて知らせるべき無断使用である
+    repo.save(&reservation).await.unwrap();
+    usecase.poll_once().await.unwrap();
+
+    assert_eq!(
+        notifier.notified().len(),
+        2,
+        "終わった予約の記録を抱え続けない"
+    );
+}


### PR DESCRIPTION
Both sets of keys that keep the reconcile pass from repeating itself only
ever grew: an opportunity that ended and a reservation that ended stayed
remembered for as long as the process ran.

A pass now keeps only the keys that still correspond to something being
observed or reserved. Repeat suppression within a live session is
unchanged; the same tests cover it.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EP2XesjWRdQ7EKhRmhEcb7

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>