### PR TITLE
feat: say why a server's usage cannot be observed

### DIFF
--- a/src/application/usecases/detect_idle_reservations_tests.rs
+++ b/src/application/usecases/detect_idle_reservations_tests.rs
@@ -10,12 +10,12 @@ use crate::domain::aggregates::resource_usage::entity::ResourceUsage;
 use crate::domain::aggregates::resource_usage::value_objects::{Gpu, Resource, TimePeriod};
 use crate::domain::common::EmailAddress;
 use crate::domain::ports::repositories::ResourceUsageRepository;
-use crate::domain::ports::{ObservationSnapshot, ObservedUsage};
+use crate::domain::ports::{ObservationSnapshot, ObservedUsage, ServerObservation};
 use crate::infrastructure::idle_reservation_notifier::MockIdleReservationNotifier;
 use crate::infrastructure::repositories::resource_usage::mock::MockUsageRepository;
 use crate::infrastructure::resource_usage_observer::MockResourceUsageObserver;
 use chrono::{DateTime, Duration, Utc};
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 const SERVER: &str = "Thalys";
@@ -97,7 +97,15 @@ fn observed_by(user_id: &str, resource: Resource, active_since: DateTime<Utc>) -
 
 /// 誰の利用も観測されなかったが、サーバーの状態は把握できている観測結果
 fn nobody_is_working() -> ObservationSnapshot {
-    ObservationSnapshot::new(Vec::new(), HashSet::from([SERVER.to_string()]))
+    ObservationSnapshot::new(
+        Vec::new(),
+        HashMap::from([(
+            SERVER.to_string(),
+            ServerObservation::Observed {
+                generated_at: Utc::now(),
+            },
+        )]),
+    )
 }
 
 #[tokio::test]
@@ -176,9 +184,11 @@ async fn a_server_that_cannot_be_observed_says_nothing_about_its_reservations() 
     let reservation = reservation_of("owner@example.com", vec![gpu(0)], Duration::hours(4));
     f.repository.save(&reservation).await.unwrap();
 
-    // レポートが届かない（cron停止・鮮度切れ）サーバー
-    f.observer
-        .set_snapshot(ObservationSnapshot::new(Vec::new(), HashSet::new()));
+    // レポートが届かない（cron停止）サーバー
+    f.observer.set_snapshot(ObservationSnapshot::new(
+        Vec::new(),
+        HashMap::from([(SERVER.to_string(), ServerObservation::Missing)]),
+    ));
 
     f.usecase.poll_once().await.unwrap();
 

--- a/src/domain/ports/mod.rs
+++ b/src/domain/ports/mod.rs
@@ -43,6 +43,6 @@ pub use resource_collection_access::{
     ResourceCollectionAccessError, ResourceCollectionAccessService,
 };
 pub use resource_usage_observer::{
-    ObservationError, ObservationSnapshot, ObservedUsage, ResourceUsageObserver,
+    ObservationError, ObservationSnapshot, ObservedUsage, ResourceUsageObserver, ServerObservation,
 };
 pub use unauthorized_usage_notifier::UnauthorizedUsageNotifier;

--- a/src/domain/ports/resource_usage_observer.rs
+++ b/src/domain/ports/resource_usage_observer.rs
@@ -4,7 +4,7 @@ use crate::domain::errors::DomainError;
 use crate::domain::ports::error::PortError;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::fmt;
 
 /// 実サーバー上で観測されたリソース利用の事実
@@ -49,6 +49,35 @@ impl ObservedUsage {
     }
 }
 
+/// 1サーバーの利用状況をいま把握できているか
+///
+/// 把握できていないときは、その理由まで持つ。理由は運用者が手を打つ手がかりになる
+/// （届いていない＝収集そのものが止まっている、古い＝収集が滞っている）。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ServerObservation {
+    /// 把握できている
+    Observed {
+        /// もとになったレポートが作られた時刻
+        generated_at: DateTime<Utc>,
+    },
+    /// レポートが届いていない
+    Missing,
+    /// レポートが古く、いまの利用状況としては使えない
+    Stale {
+        /// 使えないと判断したレポートが作られた時刻
+        generated_at: DateTime<Utc>,
+    },
+    /// レポートを読めない、または解釈できない
+    Unreadable,
+}
+
+impl ServerObservation {
+    /// このサーバーの利用状況を今このとき把握できているか
+    pub fn is_current(&self) -> bool {
+        matches!(self, Self::Observed { .. })
+    }
+}
+
 /// 一度の観測で分かったことのまとまり
 ///
 /// 「利用が観測されなかった」ことと「そのサーバーを観測できなかった」ことは異なる。
@@ -58,7 +87,7 @@ impl ObservedUsage {
 #[derive(Debug, Clone, Default)]
 pub struct ObservationSnapshot {
     usages: Vec<ObservedUsage>,
-    observed_servers: HashSet<String>,
+    servers: HashMap<String, ServerObservation>,
 }
 
 impl ObservationSnapshot {
@@ -66,12 +95,9 @@ impl ObservationSnapshot {
     ///
     /// # Arguments
     /// * `usages` - 観測された利用の一覧
-    /// * `observed_servers` - 利用の有無を把握できたサーバー名の集合
-    pub fn new(usages: Vec<ObservedUsage>, observed_servers: HashSet<String>) -> Self {
-        Self {
-            usages,
-            observed_servers,
-        }
+    /// * `servers` - サーバーごとの観測状態
+    pub fn new(usages: Vec<ObservedUsage>, servers: HashMap<String, ServerObservation>) -> Self {
+        Self { usages, servers }
     }
 
     /// 観測された利用の一覧を取得
@@ -84,12 +110,31 @@ impl ObservationSnapshot {
     /// `false`のサーバーについては、利用の一覧に現れないことが
     /// 「使われていない」ことを意味しない。
     pub fn covers(&self, server: &str) -> bool {
-        self.observed_servers.contains(server)
+        self.servers
+            .get(server)
+            .is_some_and(ServerObservation::is_current)
+    }
+
+    /// サーバーごとの観測状態をサーバー名順に取得
+    ///
+    /// 監視が動いているかを人に見せるための入り口。並び順を決めておくことで、
+    /// 表示のたびにサーバーが入れ替わって読みにくくなるのを防ぐ。
+    pub fn servers(&self) -> Vec<(&str, &ServerObservation)> {
+        let mut servers: Vec<(&str, &ServerObservation)> = self
+            .servers
+            .iter()
+            .map(|(name, observation)| (name.as_str(), observation))
+            .collect();
+        servers.sort_by_key(|(name, _)| *name);
+        servers
     }
 
     /// 利用の有無を把握できたサーバーの数
     pub fn observed_server_count(&self) -> usize {
-        self.observed_servers.len()
+        self.servers
+            .values()
+            .filter(|observation| observation.is_current())
+            .count()
     }
 }
 

--- a/src/infrastructure/resource_usage_observer/mock.rs
+++ b/src/infrastructure/resource_usage_observer/mock.rs
@@ -1,8 +1,9 @@
 use crate::domain::aggregates::resource_usage::value_objects::Resource;
 use crate::domain::ports::resource_usage_observer::{
-    ObservationError, ObservationSnapshot, ObservedUsage, ResourceUsageObserver,
+    ObservationError, ObservationSnapshot, ObservedUsage, ResourceUsageObserver, ServerObservation,
 };
 use async_trait::async_trait;
+use chrono::Utc;
 use std::sync::{Arc, Mutex};
 
 /// テスト/開発用のインメモリ観測実装
@@ -25,7 +26,12 @@ impl MockResourceUsageObserver {
     /// 「観測できたが誰も使っていないサーバー」や「観測できなかったサーバー」を
     /// 模擬したい場合は`set_snapshot`を使う。
     pub fn set_active_usages(&self, usages: Vec<ObservedUsage>) {
-        let servers = usages.iter().filter_map(server_of).collect();
+        let now = Utc::now();
+        let servers = usages
+            .iter()
+            .filter_map(server_of)
+            .map(|server| (server, ServerObservation::Observed { generated_at: now }))
+            .collect();
         *self.snapshot.lock().unwrap() = ObservationSnapshot::new(usages, servers);
     }
 

--- a/src/infrastructure/resource_usage_observer/shared_file.rs
+++ b/src/infrastructure/resource_usage_observer/shared_file.rs
@@ -1,13 +1,13 @@
 use crate::domain::aggregates::identity_link::value_objects::{ExternalIdentity, ExternalSystem};
 use crate::domain::aggregates::resource_usage::value_objects::{Gpu, Resource};
 use crate::domain::ports::resource_usage_observer::{
-    ObservationError, ObservationSnapshot, ObservedUsage, ResourceUsageObserver,
+    ObservationError, ObservationSnapshot, ObservedUsage, ResourceUsageObserver, ServerObservation,
 };
 use crate::infrastructure::config::ResourceConfig;
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tracing::warn;
@@ -79,18 +79,23 @@ impl SharedFileResourceUsageObserver {
 
     /// 1サーバー分のレポートを読む
     ///
-    /// 利用状況を把握できなかった場合は`None`を返す。読めなかったことと
+    /// 利用状況を把握できなかった場合、その理由まで返す。読めなかったことと
     /// 「使われていない」ことを呼び出し側が取り違えないようにするため、
     /// 空の一覧では表さない。
-    async fn read_server_report(&self, server_name: &str) -> Option<Vec<ObservedUsage>> {
+    async fn read_server_report(
+        &self,
+        server_name: &str,
+    ) -> (ServerObservation, Vec<ObservedUsage>) {
         let path = self.report_path(server_name);
 
         let content = match tokio::fs::read_to_string(&path).await {
             Ok(content) => content,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return (ServerObservation::Missing, Vec::new());
+            }
             Err(e) => {
                 warn!(path = %path.display(), error = %e, "reading a usage report failed");
-                return None;
+                return (ServerObservation::Unreadable, Vec::new());
             }
         };
 
@@ -98,7 +103,7 @@ impl SharedFileResourceUsageObserver {
             Ok(report) => report,
             Err(e) => {
                 warn!(path = %path.display(), error = %e, "parsing a usage report failed");
-                return None;
+                return (ServerObservation::Unreadable, Vec::new());
             }
         };
 
@@ -109,10 +114,20 @@ impl SharedFileResourceUsageObserver {
                 max_staleness_secs = self.max_staleness.num_seconds(),
                 "the usage report is too old; ignoring it"
             );
-            return None;
+            return (
+                ServerObservation::Stale {
+                    generated_at: report.generated_at,
+                },
+                Vec::new(),
+            );
         }
 
-        Some(self.build_observed_usages(&report))
+        (
+            ServerObservation::Observed {
+                generated_at: report.generated_at,
+            },
+            self.build_observed_usages(&report),
+        )
     }
 
     fn build_observed_usages(&self, report: &GpuUsageReport) -> Vec<ObservedUsage> {
@@ -157,17 +172,15 @@ impl SharedFileResourceUsageObserver {
 impl ResourceUsageObserver for SharedFileResourceUsageObserver {
     async fn observe_active_usages(&self) -> Result<ObservationSnapshot, ObservationError> {
         let mut observed = Vec::new();
-        let mut observed_servers = HashSet::new();
+        let mut servers = HashMap::new();
 
         for server in &self.resource_config.servers {
-            let Some(usages) = self.read_server_report(&server.name).await else {
-                continue;
-            };
+            let (observation, usages) = self.read_server_report(&server.name).await;
             observed.extend(usages);
-            observed_servers.insert(server.name.clone());
+            servers.insert(server.name.clone(), observation);
         }
 
-        Ok(ObservationSnapshot::new(observed, observed_servers))
+        Ok(ObservationSnapshot::new(observed, servers))
     }
 }
 
@@ -213,12 +226,18 @@ mod tests {
             !snapshot.covers("Thalys"),
             "レポートがないサーバーの利用状況は分からない"
         );
+        assert_eq!(
+            snapshot.servers(),
+            vec![("Thalys", &ServerObservation::Missing)],
+            "届いていないことが理由として分かる"
+        );
     }
 
     #[tokio::test]
     async fn test_valid_report_is_parsed() {
         let dir = temp_dir();
-        let generated_at = Utc::now();
+        let report_generated_at = Utc::now();
+        let generated_at = report_generated_at;
         let started_at = generated_at - Duration::minutes(20);
         write_report(
             &dir,
@@ -243,6 +262,16 @@ mod tests {
 
         assert_eq!(observed.len(), 1);
         assert!(snapshot.covers("Thalys"));
+        assert_eq!(
+            snapshot.servers(),
+            vec![(
+                "Thalys",
+                &ServerObservation::Observed {
+                    generated_at: report_generated_at
+                }
+            )],
+            "いつ時点の状況なのかが分かる"
+        );
         assert_eq!(observed[0].external_identity().user_id(), "kkawaguchi");
         assert_eq!(observed[0].active_since(), started_at);
         match observed[0].resource() {
@@ -260,7 +289,8 @@ mod tests {
     #[tokio::test]
     async fn a_stale_report_leaves_the_server_uncovered() {
         let dir = temp_dir();
-        let generated_at = Utc::now() - Duration::minutes(30);
+        let stale_generated_at = Utc::now() - Duration::minutes(30);
+        let generated_at = stale_generated_at;
         let started_at = generated_at - Duration::minutes(20);
         write_report(
             &dir,
@@ -286,6 +316,16 @@ mod tests {
         assert!(
             !snapshot.covers("Thalys"),
             "監視が止まっている間の沈黙を「使われていない」と読ませない"
+        );
+        assert_eq!(
+            snapshot.servers(),
+            vec![(
+                "Thalys",
+                &ServerObservation::Stale {
+                    generated_at: stale_generated_at
+                }
+            )],
+            "届いてはいるが古い、と区別できる"
         );
 
         tokio::fs::remove_dir_all(&dir).await.ok();
@@ -319,6 +359,28 @@ mod tests {
         assert!(
             snapshot.covers("Thalys"),
             "レポートは読めているので、そのサーバーの利用状況は把握できている"
+        );
+
+        tokio::fs::remove_dir_all(&dir).await.ok();
+    }
+
+    #[tokio::test]
+    async fn a_report_that_cannot_be_parsed_is_reported_as_unreadable() {
+        let dir = temp_dir();
+        write_report(&dir, "thalys.json", "{ this is not json").await;
+
+        let observer = SharedFileResourceUsageObserver::new(
+            dir.clone(),
+            test_resource_config(),
+            Duration::minutes(5),
+        );
+        let snapshot = observer.observe_active_usages().await.unwrap();
+
+        assert!(!snapshot.covers("Thalys"));
+        assert_eq!(
+            snapshot.servers(),
+            vec![("Thalys", &ServerObservation::Unreadable)],
+            "壊れたレポートは、届いていないこととは別の手当てが要る"
         );
 
         tokio::fs::remove_dir_all(&dir).await.ok();


### PR DESCRIPTION
## Why

`/status`（監視の稼働状態を管理者に見せるコマンド）を作るにあたり、いまの観測ポートでは
「そのサーバーを観測できたか」の真偽しか答えられないことが分かった。

観測できなかった理由（レポートが届いていない／古すぎる／解釈できない）は warn ログに
流れるだけで、運用者が手を打つ手がかりにならない。届かないなら収集そのものを、
古いなら滞っている原因を見る必要があり、対処が異なる。

## What

`ServerObservation` を導入し、サーバーごとに状態と理由を持たせる。

- `Observed { generated_at }` — 把握できている
- `Missing` — レポートが届いていない
- `Stale { generated_at }` — 古く、いまの利用状況としては使えない
- `Unreadable` — 読めない、または解釈できない

`covers()` は `Observed` のときだけ真を返すため、未予約利用の提案と未使用予約の検知は
これまでと同じ判断をする。

## How

`ObservationSnapshot` が持つのが `HashSet<String>` から `HashMap<String, ServerObservation>`
になった。表示に使うため `servers()` はサーバー名順に返す。

次のPRで `/status` がこれを読む。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EP2XesjWRdQ7EKhRmhEcb7