### PR TITLE
fix: rename /status, which Slack will not let an app register

### DIFF
--- a/deploy/slack-app-manifest.example.json
+++ b/deploy/slack-app-manifest.example.json
@@ -37,7 +37,7 @@
         "should_escape": false
       },
       {
-        "command": "/status",
+        "command": "/lrm-status",
         "description": "Report whether usage monitoring is working (admin)",
         "should_escape": false
       }

--- a/deploy/slack-app-manifest.example.yaml
+++ b/deploy/slack-app-manifest.example.yaml
@@ -23,7 +23,7 @@ features:
     - command: "/mcp-token"
       description: "Issue an MCP access token"
       should_escape: false
-    - command: "/status"
+    - command: "/lrm-status"
       description: "Report whether usage monitoring is working (admin)"
       should_escape: false
 oauth_config:

--- a/deploy/slack-app-manifest.ja.example.json
+++ b/deploy/slack-app-manifest.ja.example.json
@@ -37,7 +37,7 @@
         "should_escape": false
       },
       {
-        "command": "/status",
+        "command": "/lrm-status",
         "description": "実利用の監視の稼働状況を表示する（管理者用）",
         "should_escape": false
       }

--- a/deploy/slack-app-manifest.ja.example.yaml
+++ b/deploy/slack-app-manifest.ja.example.yaml
@@ -23,7 +23,7 @@ features:
     - command: "/mcp-token"
       description: "MCPアクセストークンを発行する"
       should_escape: false
-    - command: "/status"
+    - command: "/lrm-status"
       description: "実利用の監視の稼働状況を表示する（管理者用）"
       should_escape: false
 oauth_config:

--- a/docs/ADMIN_GUIDE.md
+++ b/docs/ADMIN_GUIDE.md
@@ -467,7 +467,7 @@ This opens a modal where a radio button switches between two link targets:
 Whether usage monitoring is currently working can be checked from Slack:
 
 ```text
-/status
+/lrm-status
 ```
 
 The reply — visible only to you — states the running version of
@@ -494,7 +494,7 @@ arriving.
 When monitoring stops, the post-hoc reservation proposals and the idle-reservation
 notices simply go quiet — nobody is told. Check this periodically.
 
-Using the command requires registering the `/status` slash command in your Slack
+Using the command requires registering the `/lrm-status` slash command in your Slack
 app settings ([api.slack.com/apps](https://api.slack.com/apps) → your app → Slash
 Commands).
 

--- a/docs/ADMIN_GUIDE_ja.md
+++ b/docs/ADMIN_GUIDE_ja.md
@@ -452,7 +452,7 @@ sudo systemctl enable lab-resource-manager
 実利用の監視がいま効いているかは、Slackから確認できます:
 
 ```text
-/status
+/lrm-status
 ```
 
 動いているlab-resource-managerのバージョンと起動からの経過時間、サーバーごとのレポートの
@@ -480,7 +480,7 @@ sudo systemctl enable lab-resource-manager
 監視が止まっていても、未予約利用の提案と未使用予約のお知らせが黙るだけで、誰にも通知は
 届きません。定期的に確認してください。
 
-このコマンドを使うには、Slackアプリの設定画面でスラッシュコマンド`/status`を登録する必要が
+このコマンドを使うには、Slackアプリの設定画面でスラッシュコマンド`/lrm-status`を登録する必要が
 あります（[api.slack.com/apps](https://api.slack.com/apps) → 対象アプリ → Slash Commands）。
 
 ### ログ

--- a/src/interface/slack/app_manifest.rs
+++ b/src/interface/slack/app_manifest.rs
@@ -80,7 +80,7 @@ pub const SLASH_COMMANDS: &[SlashCommandSpec] = &[
         usage_hint: None,
     },
     SlashCommandSpec {
-        command: "/status",
+        command: "/lrm-status",
         description_en: "Report whether usage monitoring is working (admin)",
         description_ja: "実利用の監視の稼働状況を表示する（管理者用）",
         usage_hint: None,
@@ -348,6 +348,48 @@ mod tests {
                     .any(|spec| spec.command == format!("/{}", command)),
                 "/{} を受け取っているが、マニフェストに宣言がない（Slackに登録されず届かない）",
                 command
+            );
+        }
+    }
+
+    /// Slackがビルトインとして持ち、アプリには使わせないコマンド
+    ///
+    /// 公式に完全な一覧は公開されていないため、これは踏んだものと広く知られたものに限る。
+    /// ここに無いからといって登録できるとは限らない。確実なのは`/lrm-`のように
+    /// アプリが分かる接頭辞を付けることで、他アプリとの衝突も同時に避けられる。
+    const KNOWN_RESERVED_COMMANDS: &[&str] = &[
+        "/apps",
+        "/away",
+        "/call",
+        "/collapse",
+        "/dm",
+        "/expand",
+        "/feed",
+        "/invite",
+        "/join",
+        "/leave",
+        "/me",
+        "/msg",
+        "/mute",
+        "/open",
+        "/prefs",
+        "/remind",
+        "/rename",
+        "/search",
+        "/shrug",
+        "/status",
+        "/topic",
+        "/who",
+        "/whois",
+    ];
+
+    #[test]
+    fn no_command_collides_with_a_slack_builtin() {
+        for spec in SLASH_COMMANDS {
+            assert!(
+                !KNOWN_RESERVED_COMMANDS.contains(&spec.command),
+                "{} はSlackが自前で持つコマンドで、アプリには登録できない",
+                spec.command
             );
         }
     }

--- a/src/interface/slack/gateway.rs
+++ b/src/interface/slack/gateway.rs
@@ -47,7 +47,9 @@ where
             "/mcp-token" => {
                 crate::interface::slack::slash_commands::mcp_token::handle(self, event).await
             }
-            "/status" => crate::interface::slack::slash_commands::status::handle(self, event).await,
+            "/lrm-status" => {
+                crate::interface::slack::slash_commands::lrm_status::handle(self, event).await
+            }
             "/free" => crate::interface::slack::slash_commands::free::handle(self, event).await,
             _ => Ok(SlackCommandEventResponse::new(
                 SlackMessageContent::new().with_text(format!("不明なコマンド: {}", command)),

--- a/src/interface/slack/slash_commands/lrm_status.rs
+++ b/src/interface/slack/slash_commands/lrm_status.rs
@@ -1,4 +1,4 @@
-//! /status コマンドハンドラ
+//! /lrm-status コマンドハンドラ
 
 use crate::domain::ports::notifier::Notifier;
 use crate::domain::ports::repositories::ResourceUsageRepository;
@@ -8,7 +8,7 @@ use chrono::Utc;
 use slack_morphism::prelude::*;
 use tracing::{debug, info};
 
-/// /status スラッシュコマンドを処理
+/// /lrm-status スラッシュコマンドを処理
 ///
 /// 実利用の監視がいま効いているかを、本人にのみ見えるメッセージで返す。
 /// 監視が止まっていても突合が黙るだけなので、確かめる手段がないと気づけない。

--- a/src/interface/slack/slash_commands/mod.rs
+++ b/src/interface/slack/slash_commands/mod.rs
@@ -23,7 +23,7 @@
 
 pub mod free;
 pub mod link_user;
+pub mod lrm_status;
 pub mod mcp_token;
 pub mod register_calendar;
 pub mod reserve;
-pub mod status;


### PR DESCRIPTION
## Why

Slackには自分のステータスを設定する `/status` がビルトインで存在し、同名のコマンドを
アプリに登録させない。#153 で追加した `/status` はSlackに登録できず、誰にも届かなかった。

## What

`/lrm-status` に改名する。スラッシュコマンドには名前空間がないため、接頭辞は
ワークスペースに入っている他アプリとの衝突も同時に避ける。

- `src/interface/slack/slash_commands/status.rs` → `lrm_status.rs`
- マニフェストの例（4ファイル）を再生成
- 管理者ガイド（日英）のコマンド名を更新

## How

既知のビルトインと衝突していないか検査するテストを足した。ただしSlackは完全な一覧を
公開していないため、これは踏んだものと広く知られたものに限る。名前を安全にするのは
接頭辞であり、テストはその補助でしかない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EP2XesjWRdQ7EKhRmhEcb7